### PR TITLE
Rework box-auth functions 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,17 +35,19 @@ Imports:
     bit64,
     rio (>= 0.5.18),
     mime,
+    glue,
+    fs,
     utils,
     stats
 Suggests:
+    clipr (>= 0.3.0),
     testthat,
     knitr,
     rmarkdown,
     purrr,
     here,
-    fs,
-    glue,
-    conflicted
+    conflicted,
+    usethis
 Remotes:
     leeper/rio
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## Improvements
 
+* modifies `box_auth()` (#96):
+  - deprecates `write.Renv` arigument
+  - copies text to the clipboard, rather than overwrite the `.Renviron` file
+  - returns `invisible(NULL)` upon success 
+
+* deprecates `box_auth_on_attach()` (#96)
+
 * adds a logo (#92, @nathancday)
 
 * converts pagination method from offset to marker-based paging (#79, @awong234)

--- a/R/boxr__internal_misc.R
+++ b/R/boxr__internal_misc.R
@@ -28,6 +28,11 @@ box_id <- function(x) {
     return(as.character(bit64::as.integer64(x)))
 }
 
+# helper to identify void values
+is_void <- function(x) {
+  is.null(x) || identical(x, "") || identical(nchar(x), 0L)  
+}
+
 
 # Function to present different package startup messages, based on whether or
 # not it looks like the user has used boxr before

--- a/R/boxr_auth.R
+++ b/R/boxr_auth.R
@@ -109,11 +109,6 @@ box_auth <- function(client_id = NULL, client_secret = NULL,
     )
   }
   
-  # helper to identify void values
-  is_void <- function(x) {
-    is.null(x) || identical(x, "") || identical(nchar(x), 0L)  
-  }
-  
   # read environment variables
   client_id_env <- Sys.getenv("BOX_CLIENT_ID")
   client_secret_env <- Sys.getenv("BOX_CLIENT_SECRET")
@@ -133,12 +128,15 @@ box_auth <- function(client_id = NULL, client_secret = NULL,
   if (is_void(client_id) && interactive()) {
     
     message(
-      "Please enter your box client id.\n",
-      "If you don't have one, hit ENTER to abort, then\n",
-      "see the documentation at ?box_auth."
+      glue::glue(
+        "Please enter your box client id.",
+        "If you don't have one, hit ENTER to abort, then",
+        "see the documentation at ?box_auth.",           
+        .sep = "\n"
+      )
     )
     client_id <- readline()
-
+    
     # Tidy up any invalid characters
     client_id <- gsub("[[:space:]]|[[:punct:]]", "", client_id)
     
@@ -150,8 +148,11 @@ box_auth <- function(client_id = NULL, client_secret = NULL,
   if (is.null(client_secret) && interactive()) {
     
     message(
-      "Please enter your box client secret\n",
-      "(Hit ENTER to abort.)"
+      glue::glue(
+        "Please enter your box client secret",
+        "(Hit ENTER to abort.)",
+        .sep = "\n"
+      )
     )
     client_secret <- readline()
 
@@ -308,6 +309,8 @@ box_fresh_auth <- function(cache = "~/.boxr-oauth", ...) {
 
 #' Obtain a Box token automatically
 #'
+#' **This function is deprecated, and will be removed at the next relase.** 
+#'  
 #' This function saves you the effort of typing [box_auth()] after
 #' the package loads. Executing `box_auth_on_attach(TRUE)` will mean that
 #' `boxr` will automatically attempt to authorize itself when

--- a/R/boxr_auth.R
+++ b/R/boxr_auth.R
@@ -1,41 +1,47 @@
 #' Obtain a Box token
 #'
 #' @description
-#' `box_auth` serves two purposes:
+#' `box_auth()` serves two purposes:
 #' 
-#' 1. Setting up box.com accounts with `boxr` for the first time
-#' 2. Connecting to previously used box.com accounts
+#' 1. connecting [box.com](https://box.com) accounts with **boxr** 
+#'    for the first time
+#' 2. connecting to previously-connected [box.com](https://box.com) accounts
 #'
 #' In either case, it should be sufficient to run `box_auth()` with no
-#' parameters. If you've authenticated with boxr before, this should be all
+#' parameters. If you have authenticated with boxr before, this should be all
 #' that is required. However, the first time you use boxr, the process is
 #' slightly more involved (see 'Getting Set-Up' below).
 #'
 #' @section Getting Set-Up:
 #' 
 #' A version of this guide is in the package vignette, with some additional
-#' screenshots. To view the vignette, run `vignette("boxr")`. To use boxr
-#' for the first time, you need to enable API access for your box.com account.
-#' The process is slightly annoying. You only need to do it once - it takes
-#' around 2 minutes.
+#' screenshots. To view the vignette, run `vignette("boxr")`, or visit this
+#' [article](https://r-box.github.io/boxr/articles/boxr.html). To use boxr
+#' for the first time, you need to enable API access for your 
+#' [box.com](https://box.com) account. The process is slightly annoying. 
+#' You only need to do it once - it takes around two minutes.
 #'
 #' The next time you use boxr, you should be able to just run
 #' `box_auth()` (without entering anything else) to be authenticated and
 #' ready-to-go.
 #' 
-#'  1. Create an app
-#'    At [Box Developers Center](https://www.box.com/developers), click on 'My Apps', in the top
-#'    right hand corner log in and create a new 'app' for your box.com account.
-#'    This won't create an app of any description; you'll simply be granting
-#'    yourself programmatic access to your files. You can call it anything you
-#'    like.
+#'  1. Create an app:
+#'
+#'     At [Box Developers Center](https://www.box.com/developers), 
+#'     click on 'My Apps', in the top
+#'     right hand corner log in and create a new 'app' for your box.com account.
+#'     This won't create an app of any description; you'll simply be granting
+#'     yourself programmatic access to your files. You can call it anything you
+#'     like.
 #'     
-#'  2. Set OAuth2 Parameters
+#'  2. Set OAuth2 Parameters:
+#'
 #'     On the next screen, you'll want to check the box for 'Content API
-#'     Access Only', and enter 'http://localhost as your
+#'     Access Only', and enter `http://localhost` as your
 #'     `redirect_uri`.
 #'     
-#'  3. Connect boxr to your account
+#'  3. Connect boxr to your account:
+#'
 #'     Run `box_auth()` and pass your `client_id` and
 #'     `client_secret` to the console when prompted. These strings are
 #'     not' enough for someone to access your account maliciously. However,
@@ -43,98 +49,144 @@
 #'     which might be shared with others.
 #'
 #' A browser window should open, for you to formally grant yourself access to
-#' your files at box.com.
+#' your files at [box.com](https://box.com).
 #'
 #' From this point on, simply running `box_auth()` at the start of a
 #' session should be all that is required.
+#' 
+#' @section Side-effects:
+#' 
+#' This function has some side effects, which make subsequent calls to 
+#' `box_auth()` easier:
+#' 
+#' - a browser window may be opened at [box.com](https://box.com), 
+#'   for you to authorize to your Box app.
+#'  
+#' - a token file is written, according to the value of `cache`. The default
+#'   behaviour is to write this file to `~/.boxr-oauth`.
 #'
-#' @param client_id Optional. The client id for the account you'd like to use.
-#'   `character`.
-#' @param client_secret Optional. The client secret for the account you'd like
-#'   to use. `character`.
-#' @param interactive `logical`. Should the authorization process happen
+#' - some global [options()] are set for your session to manage the token.
+#' 
+#' - environment variables `BOX_CLIENT_ID` and `BOX_CLIENT_SECRET` are set.
+#' 
+#' - if these environment variables have changed, and you have the 
+#'   [usethis]() package installed, it will copy some text to your clipboard
+#'   that you can paste into your `.Renviron` file.
+#' 
+#' - a message is printed to the console.  
+#' 
+#'
+#' @inheritParams httr::oauth2.0_token
+#' @param client_id `character`, 
+#'   the client id for the account to use.
+#' @param client_secret `character`, 
+#'   the client secret for the account to use. 
+#' @param interactive `logical`, should the authorization process happen
 #'   interactively (requiring user input to the R console, and/or a visit to
-#'   box.com)?
-#' @param cache Passed to `cache` in [httr()].
-#' @param write.Renv `logical`. If authentication was successful, should
-#'   `client_id` and `client_secret` be written to `.Renvirons`
-#'   in your `HOME` directory?
-#' @param ... Passed to [oauth2.0_token()]
+#'   [box.com](https://box.com))?
+#' @param write.Renv **deprecated**
+#' @param ... other arguments passed to [httr::oauth2.0_token()]
 #'
-#' @return Returns `TRUE` if connection successful, throws an error
-#'   otherwise. Invoked for it's side effect; OAuth2.0 connection to the
-#'   box.com API.
+#' @return `invisible(NULL)`, called for side-effects
 #'
-#' Your `client_id` and `client_secret` will be written to
-#' `~/.Renviron` for future use, and a token object will be wrttien to
-#' the path supplied bu `cache` (`~/.boxr-oauth` by default).
-#'
-#' See [oauth2.0_token()] for details.
+#' See [httr::oauth2.0_token()] for details.
 #'
 #' @author Brendan Rocks \email{foss@@brendanrocks.com}
 #'
-#' @seealso [box_auth_on_attach()], [oauth2.0_token()] for
-#'   details of how the tokens are handled
+#' @seealso [httr::oauth2.0_token()] for details on how tokens are handled
 #'
 #' @export
-box_auth <- function(client_id = "", client_secret = "", interactive = TRUE,
-                     cache = "~/.boxr-oauth", write.Renv = TRUE, ...) {
+#' 
+box_auth <- function(client_id = NULL, client_secret = NULL, 
+                     interactive = TRUE, cache = "~/.boxr-oauth", 
+                     write.Renv, ...) {
 
-  # If the user hasn't input any, look to .Renviron for the
-  # id and secret
-  if (client_id == "")
-    if (Sys.getenv("BOX_CLIENT_ID") != "") {
-      message("Reading client id from .Renviron")
-      client_id <- Sys.getenv("BOX_CLIENT_ID")
-    }
+  # deprecate write.Renv
+  if (!missing(write.Renv)) {
+    warning(
+      "argument `write.Renv` is deprecated; ",
+      "information provided instead at console."
+    )
+  }
+  
+  # helper to identify void values
+  is_void <- function(x) {
+    is.null(x) || identical(x, "") || identical(nchar(x), 0L)  
+  }
+  
+  # read environment variables
+  client_id_env <- Sys.getenv("BOX_CLIENT_ID")
+  client_secret_env <- Sys.getenv("BOX_CLIENT_SECRET")
+  
+  # if no input, look to .Renviron for the id and secret
+  if (is_void(client_id) && !is_void(client_id_env)) {
+    message("Using `BOX_CLIENT_ID` from environment")
+    client_id <- client_id_env
+  }
 
-  if (client_secret == "")
-    if (Sys.getenv("BOX_CLIENT_SECRET") != "") {
-      message("Reading client secret from .Renviron")
-      client_secret <- Sys.getenv("BOX_CLIENT_SECRET")
-    }
+  if (is_void(client_secret) && !is_void(client_secret_env)) {
+    message("Using `BOX_CLIENT_SECRET` from environment")
+    client_secret <- client_secret_env 
+  }
 
   # UI for interactively entering ids and secrets
-  if (client_id == "" & interactive) {
-    message("Please enter your box client id. If you don't have one")
-    message("see the documentation at ?box_auth, and hit ENTER to exit.")
+  if (is_void(client_id) && interactive()) {
+    
+    message(
+      "Please enter your box client id.\n",
+      "If you don't have one, hit ENTER to abort, then\n",
+      "see the documentation at ?box_auth."
+    )
     client_id <- readline()
 
     # Tidy up any invalid characters
     client_id <- gsub("[[:space:]]|[[:punct:]]", "", client_id)
-    if (nchar(client_id) == 0L) return()
+    
+    if (is_void(client_id)) {
+      stop("Aborting")
+    }
   }
 
-  if (client_secret == "" & interactive) {
-    message("Please enter your box client secret")
-    message("(Hit ENTER to exit.)")
+  if (is.null(client_secret) && interactive()) {
+    
+    message(
+      "Please enter your box client secret\n",
+      "(Hit ENTER to abort.)"
+    )
     client_secret <- readline()
 
     # Tidy up any invalid characters
     client_secret <- gsub("[[:space:]]|[[:punct:]]", "", client_secret)
-    if (nchar(client_secret) == 0L) return()
+    
+    if (is_void(client_secret)) {
+      stop("Aborting")
+    }
   }
 
   # At this point, a non-interactive call may still have no id & secret
-  if (client_id == "" | client_secret == "")
-    stop(paste0(
-      "box.com authorization unsuccessful; client id and/or secret not found",
-      "\nSee ?box_auth for help!"
-    ))
+  if (is_void(client_id) || is_void(client_secret)) {
+    stop(
+      "box.com authorization unsuccessful; client id and/or secret not found\n",
+      "See ?box_auth for help."
+    )
+  }
 
-  box_app <- httr::oauth_app(
+  box_app <- 
+    httr::oauth_app(
       appname = "box",
       key     = client_id,
       secret  = client_secret
     )
 
-  box_endpoint <- httr::oauth_endpoint(
+  box_endpoint <- 
+    httr::oauth_endpoint(
       authorize = "authorize",
       access    = "token",
       base_url  = "https://app.box.com/api/oauth2"
     )
 
-  box_token <- httr::oauth2.0_token(
+  box_token <- 
+    httr::oauth2.0_token(
       box_endpoint,
       box_app,
       use_oob   = getOption("httr_oob_default"),
@@ -142,15 +194,18 @@ box_auth <- function(client_id = "", client_secret = "", interactive = TRUE,
       ...
     )
 
-  if (!exists("box_token"))
+  if (!exists("box_token")) {
     stop("Login at box.com failed; unable to connect to API.")
-
+  }
+ 
   # Test the connection; retrieve the username
-  test_req <- httr::GET(
-    "https://api.box.com/2.0/folders/0", httr::config(token = box_token)
-  )
+  test_req <- 
+    httr::GET(
+      "https://api.box.com/2.0/folders/0", 
+      httr::config(token = box_token)
+    )
 
-  if (httr::http_status(test_req)$cat != "Success")
+  if (httr::http_status(test_req)$cat != "Success") 
     stop("Login at box.com failed; unable to connect to API.")
 
   cr <- httr::content(test_req)
@@ -158,7 +213,8 @@ box_auth <- function(client_id = "", client_secret = "", interactive = TRUE,
   # Write the details to the Sys.env
   app_details <-
     stats::setNames(
-      list(client_id, client_secret), c("BOX_CLIENT_ID", "BOX_CLIENT_SECRET")
+      list(client_id, client_secret), 
+      c("BOX_CLIENT_ID", "BOX_CLIENT_SECRET")
     )
 
   do.call(Sys.setenv, app_details)
@@ -173,57 +229,78 @@ box_auth <- function(client_id = "", client_secret = "", interactive = TRUE,
 
   # Let the user know they're logged in
   message(
-    paste0(
+    glue::glue(
       "boxr: Authenticated at box.com as ",
-      cr$owned_by$name, " (",
-      cr$owned_by$login, ")"
+      "{cr$owned_by$name} ({cr$owned_by$login})"
     )
   )
 
-  # Write the details to .Renviron
-  if (write.Renv) {
-
-    # Path to the R environment variables file, if it exists
-    env_path <-
-      normalizePath(paste0(Sys.getenv("HOME"), "/.Renviron"), mustWork = FALSE)
-
-    if (file.exists(env_path)) {
-      re <- readLines(env_path)
-    } else {
-      re <- NULL
-    }
-
-    # Remove any where they details were previously set, and write the new ones
-    # to the end of the file
-    writeLines(
-      c(
-        re[!grepl("BOX_CLIENT_ID=|BOX_CLIENT_SECRET=", re)],
-        paste0('BOX_CLIENT_ID="',     client_id, '"'),
-        paste0('BOX_CLIENT_SECRET="', client_secret, '"')
-      ),
-      con = env_path
+  new_client_info <- 
+    !identical(
+      c(client_id, client_secret), 
+      c(client_id_env, client_secret_env)
     )
-#     message("Writing client_id and client_secret to")
-#     message(env_path)
+
+  if (new_client_info && interactive()) {
+
+    # create a code-block for the console
+    msg_client_info <- 
+      "BOX_CLIENT_ID={client_id}\nBOX_CLIENT_SECRET={client_secret}"
+    
+    # if usethis installed, encourage to edit .Renviron
+    if (requireNamespace("usethis", quietly = FALSE)) {
+      usethis::ui_todo(
+        "You may wish to add to your {usethis::ui_code('.Renviron')} file:"
+      )
+      usethis::ui_code_block(msg_client_info)
+      usethis::ui_todo(
+        c(
+          "To edit your {usethis::ui_code('.Renviron')} file:",
+          "  - {usethis::ui_code('usethis::edit_r_environ()')}",
+          "  - check that {usethis::ui_code('.Renviron')} ends with a newline"
+        )
+      )
+    } else {
+      message(
+        glue::glue_collapse(
+          c(
+            "\nYou may wish to add the following to your `.Renviron` file:",
+            "  - check that `.Renviron` ends with a newline" ,
+            "",
+            glue::glue(msg_client_info),
+            ""
+          ),
+          sep = "\n"
+        )
+      )
+    }
+  
   }
-  return(invisible(TRUE))
+  
+  invisible(NULL)
 }
 
 
 #' Obtain a fresh Box token
 #' 
-#' Very simply, deletes the old token file before trying to re-authorise. This 
-#' is often the solution to authorisation problems raised by users!
+#' Deletes the cached token-file before trying to re-authorise. This 
+#' is often the solution to authorisation problems.
 #'
 #' @inheritParams box_auth
-#' @param ... Passed to [box_auth()]
-#'
+#' @param ... other args passed to [box_auth()]
 #' 
-#' @seealso [box_auth()] for the usual method of authorisation, and
-#'   [box_auth_on_attach()] for a lazy one.
+#' @seealso [box_auth()] for the usual method of authorisation
 #'   
 #' @export
+#' 
 box_fresh_auth <- function(cache = "~/.boxr-oauth", ...) {
+  
+  assertthat::assert_that(
+    is.character(cache),
+    fs::file_exists(cache),
+    msg = "`cache` must be a valid filename"
+  )
+  
   unlink(cache, force = TRUE)
   box_auth(cache = cache, ...)
 }
@@ -260,6 +337,14 @@ box_auth_on_attach <- function(auth_on_attach = FALSE) {
   assertthat::assert_that(!is.na(auth_on_attach))
   assertthat::assert_that(is.logical(auth_on_attach))
 
+  .Deprecated(
+    msg = "box_auth_on_attach() is deprecated; it will be removed in boxr 3.6.0"
+  )
+  
+  if (!interactive()) {
+    stop("box_auth_on_attach() can be called only interactively.")
+  }
+  
   checkAuth()
 
   # Path to the R environment variables file, if it exists

--- a/R/boxr_read.R
+++ b/R/boxr_read.R
@@ -29,7 +29,7 @@
 #' @param read_fun The function used to read the data into R. Defaults to 
 #'   [rio()]::[import()]
 #' @param fread Should the function `data.table::fread` be used to read 
-#'   `.csv` files? Passed to [rio()]::[import()] (if 
+#'   `.csv` files? Passed to [rio::import()] (if 
 #'   used).
 #' @param ... Passed to as additional parameters to read_fun
 #'   

--- a/man/box_auth.Rd
+++ b/man/box_auth.Rd
@@ -4,48 +4,44 @@
 \alias{box_auth}
 \title{Obtain a Box token}
 \usage{
-box_auth(client_id = "", client_secret = "", interactive = TRUE,
-  cache = "~/.boxr-oauth", write.Renv = TRUE, ...)
+box_auth(client_id = NULL, client_secret = NULL, interactive = TRUE,
+  cache = "~/.boxr-oauth", write.Renv, ...)
 }
 \arguments{
-\item{client_id}{Optional. The client id for the account you'd like to use.
-\code{character}.}
+\item{client_id}{\code{character},
+the client id for the account to use.}
 
-\item{client_secret}{Optional. The client secret for the account you'd like
-to use. \code{character}.}
+\item{client_secret}{\code{character},
+the client secret for the account to use.}
 
-\item{interactive}{\code{logical}. Should the authorization process happen
+\item{interactive}{\code{logical}, should the authorization process happen
 interactively (requiring user input to the R console, and/or a visit to
-box.com)?}
+\href{https://box.com}{box.com})?}
 
-\item{cache}{Passed to \code{cache} in \code{\link[=httr]{httr()}}.}
+\item{cache}{A logical value or a string. \code{TRUE} means to cache
+using the default cache file \code{.httr-oauth}, \code{FALSE} means
+don't cache, and \code{NA} means to guess using some sensible heuristics.
+A string means use the specified path as the cache file.}
 
-\item{write.Renv}{\code{logical}. If authentication was successful, should
-\code{client_id} and \code{client_secret} be written to \code{.Renvirons}
-in your \code{HOME} directory?}
+\item{write.Renv}{\strong{deprecated}}
 
-\item{...}{Passed to \code{\link[=oauth2.0_token]{oauth2.0_token()}}}
+\item{...}{other arguments passed to \code{\link[httr:oauth2.0_token]{httr::oauth2.0_token()}}}
 }
 \value{
-Returns \code{TRUE} if connection successful, throws an error
-otherwise. Invoked for it's side effect; OAuth2.0 connection to the
-box.com API.
+\code{invisible(NULL)}, called for side-effects
 
-Your \code{client_id} and \code{client_secret} will be written to
-\code{~/.Renviron} for future use, and a token object will be wrttien to
-the path supplied bu \code{cache} (\code{~/.boxr-oauth} by default).
-
-See \code{\link[=oauth2.0_token]{oauth2.0_token()}} for details.
+See \code{\link[httr:oauth2.0_token]{httr::oauth2.0_token()}} for details.
 }
 \description{
-\code{box_auth} serves two purposes:
+\code{box_auth()} serves two purposes:
 \enumerate{
-\item Setting up box.com accounts with \code{boxr} for the first time
-\item Connecting to previously used box.com accounts
+\item connecting \href{https://box.com}{box.com} accounts with \strong{boxr}
+for the first time
+\item connecting to previously-connected \href{https://box.com}{box.com} accounts
 }
 
 In either case, it should be sufficient to run \code{box_auth()} with no
-parameters. If you've authenticated with boxr before, this should be all
+parameters. If you have authenticated with boxr before, this should be all
 that is required. However, the first time you use boxr, the process is
 slightly more involved (see 'Getting Set-Up' below).
 }
@@ -53,26 +49,31 @@ slightly more involved (see 'Getting Set-Up' below).
 
 
 A version of this guide is in the package vignette, with some additional
-screenshots. To view the vignette, run \code{vignette("boxr")}. To use boxr
-for the first time, you need to enable API access for your box.com account.
-The process is slightly annoying. You only need to do it once - it takes
-around 2 minutes.
+screenshots. To view the vignette, run \code{vignette("boxr")}, or visit this
+\href{https://r-box.github.io/boxr/articles/boxr.html}{article}. To use boxr
+for the first time, you need to enable API access for your
+\href{https://box.com}{box.com} account. The process is slightly annoying.
+You only need to do it once - it takes around two minutes.
 
 The next time you use boxr, you should be able to just run
 \code{box_auth()} (without entering anything else) to be authenticated and
 ready-to-go.
 \enumerate{
-\item Create an app
-At \href{https://www.box.com/developers}{Box Developers Center}, click on 'My Apps', in the top
+\item Create an app:
+
+At \href{https://www.box.com/developers}{Box Developers Center},
+click on 'My Apps', in the top
 right hand corner log in and create a new 'app' for your box.com account.
 This won't create an app of any description; you'll simply be granting
 yourself programmatic access to your files. You can call it anything you
 like.
-\item Set OAuth2 Parameters
+\item Set OAuth2 Parameters:
+
 On the next screen, you'll want to check the box for 'Content API
-Access Only', and enter 'http://localhost as your
+Access Only', and enter \code{http://localhost} as your
 \code{redirect_uri}.
-\item Connect boxr to your account
+\item Connect boxr to your account:
+
 Run \code{box_auth()} and pass your \code{client_id} and
 \code{client_secret} to the console when prompted. These strings are
 not' enough for someone to access your account maliciously. However,
@@ -81,15 +82,33 @@ which might be shared with others.
 }
 
 A browser window should open, for you to formally grant yourself access to
-your files at box.com.
+your files at \href{https://box.com}{box.com}.
 
 From this point on, simply running \code{box_auth()} at the start of a
 session should be all that is required.
 }
 
+\section{Side-effects}{
+
+
+This function has some side effects, which make subsequent calls to
+\code{box_auth()} easier:
+\itemize{
+\item a browser window may be opened at \href{https://box.com}{box.com},
+for you to authorize to your Box app.
+\item a token file is written, according to the value of \code{cache}. The default
+behaviour is to write this file to \code{~/.boxr-oauth}.
+\item some global \code{\link[=options]{options()}} are set for your session to manage the token.
+\item environment variables \code{BOX_CLIENT_ID} and \code{BOX_CLIENT_SECRET} are set.
+\item if these environment variables have changed, and you have the
+\url{usethis} package installed, it will copy some text to your clipboard
+that you can paste into your \code{.Renviron} file.
+\item a message is printed to the console.
+}
+}
+
 \seealso{
-\code{\link[=box_auth_on_attach]{box_auth_on_attach()}}, \code{\link[=oauth2.0_token]{oauth2.0_token()}} for
-details of how the tokens are handled
+\code{\link[httr:oauth2.0_token]{httr::oauth2.0_token()}} for details on how tokens are handled
 }
 \author{
 Brendan Rocks \email{foss@brendanrocks.com}

--- a/man/box_auth_on_attach.Rd
+++ b/man/box_auth_on_attach.Rd
@@ -14,6 +14,8 @@ attached? \code{logical}}
 Nothing; invoked for it's side effect.
 }
 \description{
+\strong{This function is deprecated, and will be removed at the next relase.}
+
 This function saves you the effort of typing \code{\link[=box_auth]{box_auth()}} after
 the package loads. Executing \code{box_auth_on_attach(TRUE)} will mean that
 \code{boxr} will automatically attempt to authorize itself when

--- a/man/box_fresh_auth.Rd
+++ b/man/box_fresh_auth.Rd
@@ -7,15 +7,17 @@
 box_fresh_auth(cache = "~/.boxr-oauth", ...)
 }
 \arguments{
-\item{cache}{Passed to \code{cache} in \code{\link[=httr]{httr()}}.}
+\item{cache}{A logical value or a string. \code{TRUE} means to cache
+using the default cache file \code{.httr-oauth}, \code{FALSE} means
+don't cache, and \code{NA} means to guess using some sensible heuristics.
+A string means use the specified path as the cache file.}
 
-\item{...}{Passed to \code{\link[=box_auth]{box_auth()}}}
+\item{...}{other args passed to \code{\link[=box_auth]{box_auth()}}}
 }
 \description{
-Very simply, deletes the old token file before trying to re-authorise. This
-is often the solution to authorisation problems raised by users!
+Deletes the cached token-file before trying to re-authorise. This
+is often the solution to authorisation problems.
 }
 \seealso{
-\code{\link[=box_auth]{box_auth()}} for the usual method of authorisation, and
-\code{\link[=box_auth_on_attach]{box_auth_on_attach()}} for a lazy one.
+\code{\link[=box_auth]{box_auth()}} for the usual method of authorisation
 }

--- a/man/box_read.Rd
+++ b/man/box_read.Rd
@@ -36,7 +36,7 @@ the desired file}
 \code{\link[=rio]{rio()}}::\code{\link[=import]{import()}}}
 
 \item{fread}{Should the function \code{data.table::fread} be used to read
-\code{.csv} files? Passed to \code{\link[=rio]{rio()}}::\code{\link[=import]{import()}} (if
+\code{.csv} files? Passed to \code{\link[rio:import]{rio::import()}} (if
 used).}
 
 \item{...}{Passed to as additional parameters to read_fun}

--- a/tests/testthat/test_01_oauth.R
+++ b/tests/testthat/test_01_oauth.R
@@ -1,16 +1,19 @@
-
 # OAuth2.0 ----------------------------------------------------------------
 
 context("OAuth2.0")
+
+library("here")
+library("conflicted")
+
 # At the moment, you can only test locally
 test_that("Credentials are in the local repo", {
   skip_on_cran()
   boxr:::skip_on_travis()
   
   # .gitignore'd files on in tld of local repo
-  expect_true(file.exists("../../.client_id"))
-  expect_true(file.exists("../../.client_secret"))
-  expect_true(file.exists("../../.boxr-oauth"))
+  expect_true(file.exists(here(".client_id")))
+  expect_true(file.exists(here(".client_secret")))
+  expect_true(file.exists(here(".boxr-oauth")))
 })
 
 # See if you can log in
@@ -21,14 +24,13 @@ test_that("OAuth works", {
   expect_message(
     b <-
       box_auth(
-        client_id     = readLines("../../.client_id"),
-        client_secret = readLines("../../.client_secret"),
+        client_id     = readLines(here(".client_id")),
+        client_secret = readLines(here(".client_secret")),
         interactive = FALSE,
-        cache = "../../.boxr-oauth",
-        write.Renv = FALSE
+        cache = here(".boxr-oauth")
       ),
     "Authenticated at box.com"
   )
   
-  expect_true(b)
+  expect_null(b)
 })


### PR DESCRIPTION
This will fix #96

- deprecate `box_attach_on_auth()`
- deprecate `write.Renv` arg to `box_auth()`
  - write environment variables to console instead
- refactor `box_auth()`, `box_fresh_auth()`:
  - import glue and fs (both low depencency)

Also, fix typo in `box_read()` documentation