### PR TITLE
Update boxr_file_versions.R

### DIFF
--- a/R/boxr_file_versions.R
+++ b/R/boxr_file_versions.R
@@ -44,7 +44,7 @@ box_previous_versions <- function(file_id) {
   # Munge it into a data.frame
   d <- suppressWarnings(
     data.frame(
-      dplyr::rbind_all(lapply(
+      dplyr::bind_rows(lapply(
         httr::content(req)$entries,
         function(x) data.frame(t(unlist(x)))
       ))


### PR DESCRIPTION
We're https://github.com/tidyverse/dplyr/issues/4579 in the process of releasing dplyr 0.8.4 and this package fail at our reverse dependency checks because the `dplyr::rbind_all()` function has been formally removed after being deprecated for many versions. 

We might revert that decision because it affects a handful of packages, but in any case even if `rbind_all()` stays a little longer, you still should use `bind_rows()` instead. 

````
# boxr

<details>

* Version: 0.3.4
* Source code: https://github.com/cran/boxr
* URL: https://github.com/brendan-r/boxr/
* BugReports: https://github.com/brendan-r/boxr/issues
* Date/Publication: 2017-01-12 15:13:30
* Number of recursive dependencies: 65

Run `revdep_details(,"boxr")` for more info

</details>

## Newly broken

*   checking dependencies in R code ... NOTE
    ```
    Missing or unexported object: ‘dplyr::rbind_all’
    ```

````