### PR TITLE
address rio::import()'s behavior with JSON files 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Imports:
     dplyr,
     digest,
     bit64,
-    rio (>= 0.5.18),
+    rio,
     mime,
     glue,
     fs,
@@ -61,8 +61,6 @@ Suggests:
     sodium,
     gargle (>= 0.3.0),
     png
-Remotes:
-    leeper/rio
 VignetteBuilder: knitr
 RoxygenNote: 6.1.1
 Encoding: UTF-8

--- a/R/boxr_read.R
+++ b/R/boxr_read.R
@@ -36,7 +36,7 @@
 #' 
 #' In keeping with the spirit of `jsonlite`, `box_read_json()` has been
 #' modified to call `jsonlite::fromJSON()` directly, which by-passes the old
-#' "undersirable" behavior of `rio` (< 0.5.18). If you are using the current CRAN
+#' "undesirable" behavior of `rio` (< 0.5.18). If you are using the current CRAN
 #' release of `rio` (0.5.16) you should use `box_read_json()` to avoid these issues.
 #' 
 #' @inheritParams box_dl

--- a/R/boxr_read.R
+++ b/R/boxr_read.R
@@ -12,23 +12,31 @@
 #' provided:
 #' 
 #' \describe{
-#'   \item{`box_read_csv()`}{parse a remote CSV file into a `data.frame` using [data.table::fread()]
-#'     if available and [read.csv()] if not}
-#'   \item{`box_read_tsv()`}{parse a remote TSV file into a `data.frame` using [data.table::fread()]
-#'     if available and [read.delim()] if not }
-#'   \item{`box_read_json()`}{parse a remote JSON file into a `list` using [jsonlite::fromJSON()]}
-#'   \item{`box_read_excel()`}{parse a remote Microsoft Excel file into a `data.frame` using [readxl::read_excel()]}
-#' }
+#'   \item{`box_read_csv()`}{parse a remote CSV file into a `data.frame`. Default
+#'   read-function is [rio::import()] with `format = "csv"`, which uses [data.table::fread()] if available,
+#'   and [utils::read.csv()] if not.}
+#'   \item{`box_read_tsv()`}{parse a remote TSV file into a `data.frame`. Default
+#'   read-function is [rio::import()] with `format = "tsv"`, which uses [data.table::fread()] if available,
+#'   and [utils::read.delim()] if not.}
+#'   \item{`box_read_json()`}{parse a remote JSON file into a R object. Default
+#'   read-function is [jsonlite::fromJSON()].}
+#'   \item{`box_read_excel()`}{parse a remote Microsoft Excel file into a `data.frame`. Default
+#'   read-function is [rio::import()] with `format = "excel"`, which uses [readxl::read_excel()] by default,
+#'   but can be altered to use [openxlsx::read.xlsx()] via the argumnet `readxl = FALSE`,
+#'   which can be passed through `...` like this `boxr_read_excel(file_id, readxl = FALSE)`.}
+#'   }
 #' 
-#' @section rio::import() and JSON files:
-#' In rio (0.5.18) there was a significant change in how JSON files are processed by
-#' `rio::import()`. No longer are non-data.frame objects stored in JSON arecoherced
-#' into data.frames. This behavior is closer to the underlying function `jsonlite::fromJSON()`
-#' and similar to `readRDS()`.
+#' @section rio's import() and JSON files:
+#' In rio (0.5.18) there was a change in how JSON files are processed by
+#' [rio::import()], a non-`data.frame` object stored in JSON is no longer coerced
+#' into a `data.frame`. The old behavior would produce unexpected results or fatal errors
+#' if the stored object was not a `data.frame`. The new behavior is closer to that
+#' of the underlying function [jsonlite::fromJSON()] and similar to the behavior for RDS files.
 #' 
-#' In keeping with the spirit of `library(jsonlite)`, `box_read_json()` has been
-#' modified to call `jsonlite::fromJSON()` direcetly, which by-passes the old "undersireable"
-#' behavior or `rio` (< 0.5.18).
+#' In keeping with the spirit of `jsonlite`, `box_read_json()` has been
+#' modified to call `jsonlite::fromJSON()` directly, which by-passes the old
+#' "undersirable" behavior of `rio` (< 0.5.18). If you are using the current CRAN
+#' release of `rio` (0.5.16) you should use `box_read_json()` to avoid these issues.
 #' 
 #' @inheritParams box_dl
 #' @param type `character`, 

--- a/R/boxr_read.R
+++ b/R/boxr_read.R
@@ -14,16 +14,17 @@
 #' \describe{
 #'   \item{`box_read_csv()`}{parse a remote CSV file into a `data.frame`. Default
 #'   read-function is [rio::import()] with `format = "csv"`, which uses [data.table::fread()] if available,
-#'   and [utils::read.csv()] if not.}
+#'   and [utils::read.csv()] if not. Pass the argument `fread = FALSE` to `...`
+#'   to always use [utils::read.csv()].}
 #'   \item{`box_read_tsv()`}{parse a remote TSV file into a `data.frame`. Default
 #'   read-function is [rio::import()] with `format = "tsv"`, which uses [data.table::fread()] if available,
-#'   and [utils::read.delim()] if not.}
+#'   and [utils::read.delim()] if not. Pass the argument `fread = FALSE` to `...`
+#'   to always use [utils::read.delim()].}
 #'   \item{`box_read_json()`}{parse a remote JSON file into a R object. Default
 #'   read-function is [jsonlite::fromJSON()].}
 #'   \item{`box_read_excel()`}{parse a remote Microsoft Excel file into a `data.frame`. Default
-#'   read-function is [rio::import()] with `format = "excel"`, which uses [readxl::read_excel()] by default,
-#'   but can be altered to use [openxlsx::read.xlsx()] via the argumnet `readxl = FALSE`,
-#'   which can be passed through `...` like this `boxr_read_excel(file_id, readxl = FALSE)`.}
+#'   read-function is [rio::import()] with `format = "excel"`, which uses [readxl::read_excel()] by default.
+#'   Pass the argument `readxl = FALSE` to `...` to use [openxlsx::read.xlsx()] instead.}
 #'   }
 #' 
 #' @section rio's import() and JSON files:
@@ -45,8 +46,6 @@
 #' @param read_fun `function`, used to read (parse) the content into R; for `box_read()`
 #'   the default function is [rio::import()]; the specific helpers
 #'   each use a different function directly.
-#' @param fread `logical`, indicates to use function [data.table::fread()] 
-#'   to read CSV files.
 #' @param ... Other arguments passed to `read_fun`.
 #'   
 #' @return Object returned by function `read_fun`.   
@@ -55,7 +54,7 @@
 #'   
 #' @export
 box_read <- function(file_id, type = NULL, version_id = NULL, 
-                     version_no = NULL, read_fun = rio::import, fread = FALSE,
+                     version_no = NULL, read_fun = rio::import,
                      ...) {
   checkAuth()
   

--- a/man/box_read.Rd
+++ b/man/box_read.Rd
@@ -79,7 +79,7 @@ of the underlying function \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}}
 
 In keeping with the spirit of \code{jsonlite}, \code{box_read_json()} has been
 modified to call \code{jsonlite::fromJSON()} directly, which by-passes the old
-"undersirable" behavior of \code{rio} (< 0.5.18). If you are using the current CRAN
+"undesirable" behavior of \code{rio} (< 0.5.18). If you are using the current CRAN
 release of \code{rio} (0.5.16) you should use \code{box_read_json()} to avoid these issues.
 }
 

--- a/man/box_read.Rd
+++ b/man/box_read.Rd
@@ -31,8 +31,9 @@ used to override the content type returned by the server.}
 \item{version_no}{\code{numeric}, version of the file you'd like to download
 (starting at 1).}
 
-\item{read_fun}{\code{function}, used to read (parse) the content into R; default
-function is \code{\link[rio:import]{rio::import()}}.}
+\item{read_fun}{\code{function}, used to read (parse) the content into R; for \code{box_read()}
+the default function is \code{\link[rio:import]{rio::import()}}; the specific helpers
+each use a different function directly.}
 
 \item{fread}{\code{logical}, indicates to use function \code{\link[data.table:fread]{data.table::fread()}}
 to read CSV files.}
@@ -56,12 +57,26 @@ In addition to \code{box_read()}, some specific helpers are
 provided:
 
 \describe{
-\item{\code{box_read_csv()}}{parse a remote CSV file into a \code{data.frame} using \code{\link[=read.csv]{read.csv()}}}
-\item{\code{box_read_tsv()}}{parse a remote TSV file into a \code{data.frame} using \code{\link[=read.delim]{read.delim()}}}
+\item{\code{box_read_csv()}}{parse a remote CSV file into a \code{data.frame} using \code{\link[data.table:fread]{data.table::fread()}}
+if available and \code{\link[=read.csv]{read.csv()}} if not}
+\item{\code{box_read_tsv()}}{parse a remote TSV file into a \code{data.frame} using \code{\link[data.table:fread]{data.table::fread()}}
+if available and \code{\link[=read.delim]{read.delim()}} if not }
 \item{\code{box_read_json()}}{parse a remote JSON file into a \code{list} using \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}}}
 \item{\code{box_read_excel()}}{parse a remote Microsoft Excel file into a \code{data.frame} using \code{\link[readxl:read_excel]{readxl::read_excel()}}}
 }
 }
+\section{rio}{
+:import() and JSON files:
+In rio (0.5.18) there was a significant change in how JSON files are processed by
+\code{rio::import()}. No longer are non-data.frame objects stored in JSON arecoherced
+into data.frames. This behavior is closer to the underlying function \code{jsonlite::fromJSON()}
+and similar to \code{readRDS()}.
+
+In keeping with the spirit of \code{library(jsonlite)}, \code{box_read_json()} has been
+modified to call \code{jsonlite::fromJSON()} direcetly, which by-passes the old "undersireable"
+behavior or \code{rio} (< 0.5.18).
+}
+
 \seealso{
 \code{\link[=box_dl]{box_dl()}}, \code{\link[=box_save]{box_save()}}, \code{\link[=box_source]{box_source()}}
 }

--- a/man/box_read.Rd
+++ b/man/box_read.Rd
@@ -9,7 +9,7 @@
 \title{Read an R object from a Box file}
 \usage{
 box_read(file_id, type = NULL, version_id = NULL, version_no = NULL,
-  read_fun = rio::import, fread = FALSE, ...)
+  read_fun = rio::import, ...)
 
 box_read_csv(file_id, ...)
 
@@ -35,9 +35,6 @@ used to override the content type returned by the server.}
 the default function is \code{\link[rio:import]{rio::import()}}; the specific helpers
 each use a different function directly.}
 
-\item{fread}{\code{logical}, indicates to use function \code{\link[data.table:fread]{data.table::fread()}}
-to read CSV files.}
-
 \item{...}{Other arguments passed to \code{read_fun}.}
 }
 \value{
@@ -59,16 +56,17 @@ provided:
 \describe{
 \item{\code{box_read_csv()}}{parse a remote CSV file into a \code{data.frame}. Default
 read-function is \code{\link[rio:import]{rio::import()}} with \code{format = "csv"}, which uses \code{\link[data.table:fread]{data.table::fread()}} if available,
-and \code{\link[utils:read.csv]{utils::read.csv()}} if not.}
+and \code{\link[utils:read.csv]{utils::read.csv()}} if not. Pass the argument \code{fread = FALSE} to \code{...}
+to always use \code{\link[utils:read.csv]{utils::read.csv()}}.}
 \item{\code{box_read_tsv()}}{parse a remote TSV file into a \code{data.frame}. Default
 read-function is \code{\link[rio:import]{rio::import()}} with \code{format = "tsv"}, which uses \code{\link[data.table:fread]{data.table::fread()}} if available,
-and \code{\link[utils:read.delim]{utils::read.delim()}} if not.}
+and \code{\link[utils:read.delim]{utils::read.delim()}} if not. Pass the argument \code{fread = FALSE} to \code{...}
+to always use \code{\link[utils:read.delim]{utils::read.delim()}}.}
 \item{\code{box_read_json()}}{parse a remote JSON file into a R object. Default
 read-function is \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}}.}
 \item{\code{box_read_excel()}}{parse a remote Microsoft Excel file into a \code{data.frame}. Default
-read-function is \code{\link[rio:import]{rio::import()}} with \code{format = "excel"}, which uses \code{\link[readxl:read_excel]{readxl::read_excel()}} by default,
-but can be altered to use \code{\link[openxlsx:read.xlsx]{openxlsx::read.xlsx()}} via the argumnet \code{readxl = FALSE},
-which can be passed through \code{...} like this \code{boxr_read_excel(file_id, readxl = FALSE)}.}
+read-function is \code{\link[rio:import]{rio::import()}} with \code{format = "excel"}, which uses \code{\link[readxl:read_excel]{readxl::read_excel()}} by default.
+Pass the argument \code{readxl = FALSE} to \code{...} to use \code{\link[openxlsx:read.xlsx]{openxlsx::read.xlsx()}} instead.}
 }
 }
 \section{rio's import() and JSON files}{

--- a/man/box_read.Rd
+++ b/man/box_read.Rd
@@ -57,24 +57,32 @@ In addition to \code{box_read()}, some specific helpers are
 provided:
 
 \describe{
-\item{\code{box_read_csv()}}{parse a remote CSV file into a \code{data.frame} using \code{\link[data.table:fread]{data.table::fread()}}
-if available and \code{\link[=read.csv]{read.csv()}} if not}
-\item{\code{box_read_tsv()}}{parse a remote TSV file into a \code{data.frame} using \code{\link[data.table:fread]{data.table::fread()}}
-if available and \code{\link[=read.delim]{read.delim()}} if not }
-\item{\code{box_read_json()}}{parse a remote JSON file into a \code{list} using \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}}}
-\item{\code{box_read_excel()}}{parse a remote Microsoft Excel file into a \code{data.frame} using \code{\link[readxl:read_excel]{readxl::read_excel()}}}
+\item{\code{box_read_csv()}}{parse a remote CSV file into a \code{data.frame}. Default
+read-function is \code{\link[rio:import]{rio::import()}} with \code{format = "csv"}, which uses \code{\link[data.table:fread]{data.table::fread()}} if available,
+and \code{\link[utils:read.csv]{utils::read.csv()}} if not.}
+\item{\code{box_read_tsv()}}{parse a remote TSV file into a \code{data.frame}. Default
+read-function is \code{\link[rio:import]{rio::import()}} with \code{format = "tsv"}, which uses \code{\link[data.table:fread]{data.table::fread()}} if available,
+and \code{\link[utils:read.delim]{utils::read.delim()}} if not.}
+\item{\code{box_read_json()}}{parse a remote JSON file into a R object. Default
+read-function is \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}}.}
+\item{\code{box_read_excel()}}{parse a remote Microsoft Excel file into a \code{data.frame}. Default
+read-function is \code{\link[rio:import]{rio::import()}} with \code{format = "excel"}, which uses \code{\link[readxl:read_excel]{readxl::read_excel()}} by default,
+but can be altered to use \code{\link[openxlsx:read.xlsx]{openxlsx::read.xlsx()}} via the argumnet \code{readxl = FALSE},
+which can be passed through \code{...} like this \code{boxr_read_excel(file_id, readxl = FALSE)}.}
 }
 }
-\section{rio}{
-:import() and JSON files:
-In rio (0.5.18) there was a significant change in how JSON files are processed by
-\code{rio::import()}. No longer are non-data.frame objects stored in JSON arecoherced
-into data.frames. This behavior is closer to the underlying function \code{jsonlite::fromJSON()}
-and similar to \code{readRDS()}.
+\section{rio's import() and JSON files}{
 
-In keeping with the spirit of \code{library(jsonlite)}, \code{box_read_json()} has been
-modified to call \code{jsonlite::fromJSON()} direcetly, which by-passes the old "undersireable"
-behavior or \code{rio} (< 0.5.18).
+In rio (0.5.18) there was a change in how JSON files are processed by
+\code{\link[rio:import]{rio::import()}}, a non-\code{data.frame} object stored in JSON is no longer coerced
+into a \code{data.frame}. The old behavior would produce unexpected results or fatal errors
+if the stored object was not a \code{data.frame}. The new behavior is closer to that
+of the underlying function \code{\link[jsonlite:fromJSON]{jsonlite::fromJSON()}} and similar to the behavior for RDS files.
+
+In keeping with the spirit of \code{jsonlite}, \code{box_read_json()} has been
+modified to call \code{jsonlite::fromJSON()} directly, which by-passes the old
+"undersirable" behavior of \code{rio} (< 0.5.18). If you are using the current CRAN
+release of \code{rio} (0.5.16) you should use \code{box_read_json()} to avoid these issues.
 }
 
 \seealso{

--- a/tests/testthat/test_05_read_write.R
+++ b/tests/testthat/test_05_read_write.R
@@ -48,7 +48,7 @@ test_that("You can write/read a remote .csv file", {
   # box_read_csv()
   #
   # Can you read it in?
-  expect_message(df2 <- box_read_csv(b$id), "read")
+  expect_message(df2 <- box_read_csv(b$id, stringsAsFactors = FALSE), "read")
   # Did the script execute correctly?
   expect_equal(df, df2)
 })
@@ -89,28 +89,18 @@ test_that("You can write/read a remote .json file", {
   
   # Write a little .json file
   tf <- paste0(tempfile(), ".json")
-  df <- data.frame(a = letters[1:5], b = 1:5, c = round(rnorm(5), 3), 
+  df <- data.frame(a = letters[1:5], b = 1:5, c = rnorm(5),
                    stringsAsFactors = FALSE)
   l  <- list(a = 1:10, b = matrix(1, 3, 3), c = df)
   
-  writeLines(jsonlite::toJSON(l), tf)
+  writeLines(jsonlite::toJSON(l, digits = NA), tf) # default will round digits to 4 decimal places 
   
-  # Upload it, so that you can 'read it' back down
   b <- box_ul(0, tf)
   
-  # box_read()
-  #
-  # Can you read it in?
-  expect_message(l2 <- box_read(b$id), "read")
-  # Did the script execute correctly?
-  expect_equal(l, l2)
+  # passing `read_fun` directly until rio (>= 0.5.18) goes to CRAN
+  expect_message(l2 <- box_read(b$id, read_fun = jsonlite::fromJSON), "read")
+  expect_equivalent(l, l2)
 
-  # box_read_json()
-  #
-  # Can you read it in?
   expect_message(l2 <- box_read_json(b$id), "read")
-  # Did the script execute correctly?
   expect_equal(l, l2)
-
 })
-


### PR DESCRIPTION
By updating box_read_json to use `jsonlite::fromJSON()` directly, fix #130

Right now I'm passing `read_fun` directly to the first JSON test for `box_read()`.  Not sure if this is the best, or if it would be better just to comment out until rio (>= 0.5.18) hits CRAN.

Also stumbled across (and fixed/updated) some nuances:

*  `rio` uses `data.table::fread()` for delimited files when possible 
* `jsonlite::toJSON()` rounding numbers to 4 decimal places.
