### PR TITLE
update is_void() and the boxr_object_list S3 methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,6 +62,6 @@ Suggests:
     gargle (>= 0.3.0),
     png
 VignetteBuilder: knitr
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,13 +45,13 @@ Imports:
     fs,
     utils,
     stats,
-    rlang
+    rlang,
+    purrr
 Suggests:
     clipr (>= 0.3.0),
     testthat,
     knitr,
     rmarkdown,
-    purrr,
     here,
     conflicted,
     usethis,

--- a/R/boxr__internal_misc.R
+++ b/R/boxr__internal_misc.R
@@ -33,8 +33,7 @@ is_void <- function(x) {
   is.null(x) ||
     identical(x, "") ||
     identical(nchar(x), integer(0)) ||
-    is.na(x) ||
-    (is.list(x) & length(x) ==0)
+    is.na(x)
 }
 
 # helper to discriminate on void values, similar to %||%

--- a/R/boxr__internal_misc.R
+++ b/R/boxr__internal_misc.R
@@ -33,7 +33,7 @@ is_void <- function(x) {
   is.null(x) ||
     identical(x, "") ||
     identical(nchar(x), integer(0)) ||
-    is.na(x)
+    all(is.na(x))
 }
 
 # helper to discriminate on void values, similar to %||%

--- a/R/boxr__internal_misc.R
+++ b/R/boxr__internal_misc.R
@@ -32,18 +32,16 @@ box_id <- function(x) {
 is_void <- function(x) {
   is.null(x) ||
     identical(x, "") ||
-    identical(nchar(x), 0L) ||
+    identical(nchar(x), integer(0)) ||
     is.na(x) ||
     (is.list(x) & length(x) ==0)
 }
 
 # helper to discriminate on void values, similar to %||%
 `%|0|%` <- function(x, y) {
-  
   if (is_void(x)) {
     return (y)
   }
-  
   x
 }
 

--- a/R/boxr__internal_misc.R
+++ b/R/boxr__internal_misc.R
@@ -30,7 +30,11 @@ box_id <- function(x) {
 
 # helper to identify void values
 is_void <- function(x) {
-  is.null(x) || identical(x, "") || identical(nchar(x), 0L) || is.na(x) 
+  is.null(x) ||
+    identical(x, "") ||
+    identical(nchar(x), 0L) ||
+    is.na(x) ||
+    (is.list(x) & length(x) ==0)
 }
 
 # helper to discriminate on void values, similar to %||%

--- a/R/boxr_delete_restore.R
+++ b/R/boxr_delete_restore.R
@@ -25,7 +25,7 @@
 #' 
 #' @export
 box_delete_file <- function(file_id) {
-  add_file_ref_class(httr::content(boxDeleteFile(file_id)))
+  invisible(boxDeleteFile(file_id))
 }
 
 #' @rdname box_delete_file

--- a/R/boxr_file_versions.R
+++ b/R/boxr_file_versions.R
@@ -36,9 +36,9 @@ box_previous_versions <- function(file_id) {
   
   # The box API isn't very helpful if there are no previous versions. If this
   # is the case, let the user know and exit.
-  if (is.null(httr::content(req)[["entries"]])) {
+  if (is_void(httr::content(req)[["entries"]])) {
     message("No previous versions for this file found.")
-    return(NULL)
+    return(invisible(NULL))
   }
   
   # Munge it into a data.frame

--- a/R/boxr_file_versions.R
+++ b/R/boxr_file_versions.R
@@ -34,7 +34,7 @@ box_previous_versions <- function(file_id) {
     get_token()
   )
   
-  # The box API isn't very helpful if there are no previous versions. If this
+# The box API isn't very helpful if there are no previous versions. If this
   # is the case, let the user know and exit.
   if (is_void(httr::content(req)[["entries"]])) {
     message("No previous versions for this file found.")

--- a/R/boxr_s3_classes.R
+++ b/R/boxr_s3_classes.R
@@ -125,7 +125,7 @@ as.data.frame.boxr_object_list <- function(x, ...) {
       owner               = x$owned_by$login,
       path                = path,
       modified_at         = box_datetime(x$modified_at),
-      content_modified_at = box_datetime(x$content_modified_at) %|0|% NA_integer_,
+      content_modified_at = box_datetime(x$content_modified_at) %|0|% as.POSIXct(NA),
       sha1                = x$sha1 %|0|% NA_character_,
       version             = as.numeric(x$etag) + 1,
       stringsAsFactors    = FALSE

--- a/R/boxr_s3_classes.R
+++ b/R/boxr_s3_classes.R
@@ -120,13 +120,13 @@ as.data.frame.boxr_object_list <- function(x, ...) {
       name                = x$name,
       type                = x$type,
       id                  = x$id,
-      size                = x$size,
+      size                = x$size %|0|% NA,
       description         = x$description,
       owner               = x$owned_by$login,
       path                = path,
       modified_at         = box_datetime(x$modified_at),
-      content_modified_at = box_datetime(x$content_modified_at),
-      sha1                = ifelse(is.null(x$sha1), NA, x$sha1),
+      content_modified_at = box_datetime(x$content_modified_at) %|0|% NA,
+      sha1                = x$sha1 %|0|% NA,
       version             = as.numeric(x$etag) + 1,
       stringsAsFactors    = FALSE
     )
@@ -160,7 +160,7 @@ print.boxr_object_list <- function(x, ...) {
     df$description <- trunc_end(df$description)
   
   df$path        <- trunc_start(df$path)
-  df$size        <- format_bytes(df$size)
+  df$size        <- purrr::map_chr(df$size, purrr::possibly(format_bytes, NA))
   
   cat(paste0("\nbox.com remote object list (", length(x), " objects)\n\n"))
   cat(paste0("  Summary of first ", nrow(df), ":\n\n"))

--- a/R/boxr_s3_classes.R
+++ b/R/boxr_s3_classes.R
@@ -120,13 +120,13 @@ as.data.frame.boxr_object_list <- function(x, ...) {
       name                = x$name,
       type                = x$type,
       id                  = x$id,
-      size                = x$size %|0|% NA,
+      size                = x$size %|0|% NA_integer_,
       description         = x$description,
       owner               = x$owned_by$login,
       path                = path,
       modified_at         = box_datetime(x$modified_at),
-      content_modified_at = box_datetime(x$content_modified_at) %|0|% NA,
-      sha1                = x$sha1 %|0|% NA,
+      content_modified_at = box_datetime(x$content_modified_at) %|0|% NA_integer_,
+      sha1                = x$sha1 %|0|% NA_character_,
       version             = as.numeric(x$etag) + 1,
       stringsAsFactors    = FALSE
     )

--- a/man/boxGet.Rd
+++ b/man/boxGet.Rd
@@ -4,8 +4,14 @@
 \alias{boxGet}
 \title{Issue a get request for a file stored on box.com}
 \usage{
-boxGet(file_id, local_file, version_id = NULL, version_no = NULL,
-  download = FALSE, pb = FALSE)
+boxGet(
+  file_id,
+  local_file,
+  version_id = NULL,
+  version_no = NULL,
+  download = FALSE,
+  pb = FALSE
+)
 }
 \description{
 This internal function is shared by \code{\link[=box_dl]{box_dl()}}, and the

--- a/man/box_auth.Rd
+++ b/man/box_auth.Rd
@@ -4,8 +4,14 @@
 \alias{box_auth}
 \title{Authenticate to Box (interactive-app)}
 \usage{
-box_auth(client_id = NULL, client_secret = NULL, interactive = TRUE,
-  cache = "~/.boxr-oauth", write.Renv, ...)
+box_auth(
+  client_id = NULL,
+  client_secret = NULL,
+  interactive = TRUE,
+  cache = "~/.boxr-oauth",
+  write.Renv,
+  ...
+)
 }
 \arguments{
 \item{client_id}{\code{character},
@@ -62,7 +68,7 @@ This function has some side effects which make subsequent calls to
 \item a browser window may be opened at \href{https://developer.box.com/docs}{box.com},
 for you to authorize to your Box app.
 \item a token file is written, according to the value of \code{cache}. The default
-behaviour is to write this file to \code{~/.boxr-oauth}.
+behaviour is to write this file to \verb{~/.boxr-oauth}.
 \item some global \code{\link[=options]{options()}} are set for your session to manage the token.
 \item environment variables \code{BOX_USER_ID}, \code{BOX_CLIENT_ID},
 and \code{BOX_CLIENT_SECRET} are set.

--- a/man/box_auth_service.Rd
+++ b/man/box_auth_service.Rd
@@ -9,7 +9,7 @@ box_auth_service(token_file = NULL, token_text = NULL)
 \arguments{
 \item{token_file}{\code{character}, path to JSON token-file. If not provided,
 the function will look for an environment variable \code{BOX_TOKEN_FILE}. If
-that is not there, it will try \code{~/.boxr-auth/token.json}.}
+that is not there, it will try \verb{~/.boxr-auth/token.json}.}
 
 \item{token_text}{\code{character}, JSON text. If this is provided,
 \code{token_file} is ignored.}

--- a/man/box_dir_diff.Rd
+++ b/man/box_dir_diff.Rd
@@ -4,8 +4,12 @@
 \alias{box_dir_diff}
 \title{Compare the contents of Remote and Local Directories}
 \usage{
-box_dir_diff(dir_id = box_getwd(), local_dir = getwd(), load = "up",
-  folders = FALSE)
+box_dir_diff(
+  dir_id = box_getwd(),
+  local_dir = getwd(),
+  load = "up",
+  folders = FALSE
+)
 }
 \arguments{
 \item{dir_id}{The id of the box.com folder which you'd like to use for the

--- a/man/box_dir_invite.Rd
+++ b/man/box_dir_invite.Rd
@@ -4,8 +4,13 @@
 \alias{box_dir_invite}
 \title{Invite collaboration on a Box folder}
 \usage{
-box_dir_invite(dir_id, user_id, login = NULL, role = "viewer",
-  can_view_path = FALSE)
+box_dir_invite(
+  dir_id,
+  user_id,
+  login = NULL,
+  role = "viewer",
+  can_view_path = FALSE
+)
 }
 \arguments{
 \item{dir_id}{\code{numeric} or \code{character}, folder ID at Box.}

--- a/man/box_dl.Rd
+++ b/man/box_dl.Rd
@@ -5,12 +5,23 @@
 \alias{box_ul}
 \title{Download/upload files from/to Box}
 \usage{
-box_dl(file_id, local_dir = getwd(), overwrite = FALSE,
-  file_name = NULL, version_id = NULL, version_no = NULL,
-  pb = options()$boxr.progress, filename)
+box_dl(
+  file_id,
+  local_dir = getwd(),
+  overwrite = FALSE,
+  file_name = NULL,
+  version_id = NULL,
+  version_no = NULL,
+  pb = options()$boxr.progress,
+  filename
+)
 
-box_ul(dir_id = box_getwd(), file, pb = options()$boxr.progress,
-  description = NULL)
+box_ul(
+  dir_id = box_getwd(),
+  file,
+  pb = options()$boxr.progress,
+  description = NULL
+)
 }
 \arguments{
 \item{file_id}{\code{numeric} or \code{character}, file ID at Box.}

--- a/man/box_fetch.Rd
+++ b/man/box_fetch.Rd
@@ -5,11 +5,21 @@
 \alias{box_push}
 \title{Download/upload directories from/to Box}
 \usage{
-box_fetch(dir_id = box_getwd(), local_dir = getwd(),
-  recursive = TRUE, overwrite = FALSE, delete = FALSE)
+box_fetch(
+  dir_id = box_getwd(),
+  local_dir = getwd(),
+  recursive = TRUE,
+  overwrite = FALSE,
+  delete = FALSE
+)
 
-box_push(dir_id = box_getwd(), local_dir = getwd(),
-  ignore_dots = TRUE, overwrite = FALSE, delete = FALSE)
+box_push(
+  dir_id = box_getwd(),
+  local_dir = getwd(),
+  ignore_dots = TRUE,
+  overwrite = FALSE,
+  delete = FALSE
+)
 }
 \arguments{
 \item{dir_id}{\code{numeric} or \code{character}, folder ID at Box.}

--- a/man/box_previous_versions.Rd
+++ b/man/box_previous_versions.Rd
@@ -17,7 +17,8 @@ versions of the file (if available).
 Box explicitly versions files; this function returns a
 \code{data.frame} containing information on a file's previous
 versions on Box. No information about the current version of the file is
-returned.
+returned. If the version of a file is one, then NULL is returned invisibly
+along with a helpful message.
 }
 \details{
 The returned \code{data.frame} contains a variable, \code{file_version_id},

--- a/man/box_read.Rd
+++ b/man/box_read.Rd
@@ -8,8 +8,14 @@
 \alias{box_read_excel}
 \title{Read an R object from a Box file}
 \usage{
-box_read(file_id, type = NULL, version_id = NULL, version_no = NULL,
-  read_fun = rio::import, ...)
+box_read(
+  file_id,
+  type = NULL,
+  version_id = NULL,
+  version_no = NULL,
+  read_fun = rio::import,
+  ...
+)
 
 box_read_csv(file_id, ...)
 

--- a/man/box_save.Rd
+++ b/man/box_save.Rd
@@ -6,11 +6,14 @@
 \alias{box_save_image}
 \title{Download/upload an R workspace from/to a Box file}
 \usage{
-box_save(..., dir_id = box_getwd(), file_name = ".RData",
-  description = NULL)
+box_save(..., dir_id = box_getwd(), file_name = ".RData", description = NULL)
 
-box_save_image(dir_id = box_getwd(), file_name = ".RData",
-  description = NULL, filename)
+box_save_image(
+  dir_id = box_getwd(),
+  file_name = ".RData",
+  description = NULL,
+  filename
+)
 
 box_load(file_id)
 }

--- a/man/box_search.Rd
+++ b/man/box_search.Rd
@@ -7,12 +7,19 @@
 \alias{box_search_trash}
 \title{Search Box files}
 \usage{
-box_search(query = "", content_types = c("name", "description",
-  "file_content", "comments", "tags"), type = NULL,
-  file_extensions = NULL, ancestor_folder_ids = NULL,
-  created_at_range = NULL, updated_at_range = NULL,
-  size_range = NULL, trash = FALSE, owner_user_ids = NULL,
-  max = 200)
+box_search(
+  query = "",
+  content_types = c("name", "description", "file_content", "comments", "tags"),
+  type = NULL,
+  file_extensions = NULL,
+  ancestor_folder_ids = NULL,
+  created_at_range = NULL,
+  updated_at_range = NULL,
+  size_range = NULL,
+  trash = FALSE,
+  owner_user_ids = NULL,
+  max = 200
+)
 
 box_search_files(query, ...)
 

--- a/man/box_write.Rd
+++ b/man/box_write.Rd
@@ -4,8 +4,15 @@
 \alias{box_write}
 \title{Write an R object to a Box file}
 \usage{
-box_write(x, file_name, dir_id = box_getwd(), description = NULL,
-  write_fun = rio::export, filename, ...)
+box_write(
+  x,
+  file_name,
+  dir_id = box_getwd(),
+  description = NULL,
+  write_fun = rio::export,
+  filename,
+  ...
+)
 }
 \arguments{
 \item{x}{Object to be written.}

--- a/man/downloadDirFiles.Rd
+++ b/man/downloadDirFiles.Rd
@@ -9,8 +9,12 @@
 \usage{
 deleteRemoteObjects(dir_id, local_dir = getwd())
 
-downloadDirFiles(dir_id, local_dir = getwd(), overwrite = TRUE,
-  dir_str = getwd())
+downloadDirFiles(
+  dir_id,
+  local_dir = getwd(),
+  overwrite = TRUE,
+  dir_str = getwd()
+)
 
 uploadDirFiles(dir_id, local_dir = getwd(), overwrite = TRUE)
 }

--- a/tests/testthat/test_08_versions.R
+++ b/tests/testthat/test_08_versions.R
@@ -1,5 +1,4 @@
 
-
 # Versions ----------------------------------------------------------------
 
 context("Versions")
@@ -22,6 +21,8 @@ test_that("Versions work", {
   expect_is(ul, "boxr_file_reference")
   
   v_file_id <- ul$id
+  
+  expect_message(box_previous_versions(v_file_id), "No previous versions")
   
   # Upload subsequent versions
   for (v in 2:n_versions) {

--- a/tests/testthat/test_08_versions.R
+++ b/tests/testthat/test_08_versions.R
@@ -34,6 +34,7 @@ test_that("Versions work", {
       paste0("Attempting to upload new version \\(V", v, "\\)")
     )
     
+    
     # Do they have the right class?
     expect_is(ul, "boxr_file_reference")
     


### PR DESCRIPTION
Fix #139 by updating `is_void()` and using it in `box_previous_versions()` to send a message (tested for) instead of an error when no prior versions exist (e.g. current file version is 1) 

Fix #140 support web-links in `boxr_object_list` S3 methods by using the `%|0|%` operator and `purrr` functions to handle missing slots (size, content_modified_at, sha1) in the API result for `web-link` type objects. (Not sure how to test this without adding a new function to create a bookmark on Box, might be an issue to wait for `cardboard`/low-level API support)

