### PR TITLE
replaced httr one-shot functions with httr::RETRY()

### DIFF
--- a/R/boxr__internal_get.R
+++ b/R/boxr__internal_get.R
@@ -72,7 +72,8 @@ boxGet <- function(file_id, local_file, version_id = NULL, version_no = NULL,
       stop("version_id must be an integer, 11 characters in length")
     
     # The call with the version url parameter
-    req <- httr::GET(
+    req <- httr::RETRY(
+      "GET",
       paste0(
         "https://api.box.com/2.0/files/",
         file_id, "/content", "?version=", version_id
@@ -81,11 +82,13 @@ boxGet <- function(file_id, local_file, version_id = NULL, version_no = NULL,
         httr::write_disk(local_file, TRUE),
       if (pb)
         httr::progress(),
-      get_token()
+      get_token(),
+      terminate_on = c(403, 404)
     )
   } else {
     # The call without the version url parameter (e.g the latest version)
-    req <- httr::GET(
+    req <- httr::RETRY(
+      "GET",
       paste0(
         "https://api.box.com/2.0/files/",
         file_id, "/content"
@@ -94,7 +97,8 @@ boxGet <- function(file_id, local_file, version_id = NULL, version_no = NULL,
         httr::write_disk(local_file, TRUE),
       if (pb)
         httr::progress(),
-      get_token()
+      get_token(),
+      terminate_on = c(403, 404)
     ) 
   }
   

--- a/R/boxr__internal_update_upload.R
+++ b/R/boxr__internal_update_upload.R
@@ -18,7 +18,8 @@
 #' @keywords internal
 #' 
 box_upload_new <- function(dir_id, file, pb = FALSE) {
-  httr::POST(
+  httr::RETRY(
+    "POST",
     "https://upload.box.com/api/2.0/files/content",
     get_token(),
     encode = "multipart",
@@ -32,14 +33,16 @@ box_upload_new <- function(dir_id, file, pb = FALSE) {
             ,'"}}'
           ),
         file = httr::upload_file(file)
-      )
+      ),
+    terminate_on = c(403, 404)
   )
 }
 
 #' @rdname box_upload_new
 #' @keywords internal
 box_update_file <- function(file_id, file, dir_id, pb = FALSE) {
-  httr::POST(
+  httr::RETRY(
+    "POST",
     paste0("https://upload.box.com/api/2.0/files/", box_id(file_id), 
            "/content"),
     get_token(),
@@ -54,6 +57,7 @@ box_update_file <- function(file_id, file, dir_id, pb = FALSE) {
             ,'"}}'
           ),
         file = httr::upload_file(file)
-      )
+      ),
+    terminate_on = c(403, 404)
   )
 }

--- a/R/boxr_add_description.R
+++ b/R/boxr_add_description.R
@@ -15,10 +15,12 @@
 box_add_description <- function(file_id, description) {
   file_id <- handle_file_id(file_id)
   
-  req <- httr::PUT(
+  req <- httr::RETRY(
+    "PUT",
     paste0("https://api.box.com/2.0/files/", file_id),
     body = paste0('{"description":"', description, '"}'),
-    get_token()
+    get_token(),
+    terminate_on = c(403, 404)
   )
   
   httr::stop_for_status(req)

--- a/R/boxr_delete_restore.R
+++ b/R/boxr_delete_restore.R
@@ -31,12 +31,14 @@ box_delete_file <- function(file_id) {
 #' @rdname box_delete_file
 #' @export
 box_restore_file <- function(file_id) {
-  req <- httr::POST(
+  req <- httr::RETRY(
+    "POST",
     paste0(
       "https://api.box.com/2.0/file/",
       file_id
     ),
-    get_token()
+    get_token(),
+    terminate_on = c(403, 404)
   )
   
   if (httr::http_status(req)$message == "Success: (201) Created")
@@ -59,12 +61,14 @@ box_delete_folder <- function(dir_id) {
 #' @rdname box_delete_file
 #' @export
 box_restore_folder <- function(dir_id) {
-  req <- httr::POST(
+  req <- httr::RETRY(
+    "POST",
     paste0(
       "https://api.box.com/2.0/folders/",
       dir_id
     ),
-    get_token()
+    get_token(),
+    terminate_on = c(403, 404)
   )
   
   if (httr::http_status(req)$message == "Success: (201) Created")
@@ -86,12 +90,14 @@ box_restore_folder <- function(dir_id) {
 
 #' @keywords internal
 boxDeleteFile <- function(file_id) {
-  req <- httr::DELETE(
+  req <- httr::RETRY(
+    "DELETE",
     paste0(
       "https://api.box.com/2.0/files/",
       file_id
     ),
-    get_token()
+    get_token(),
+    terminate_on = c(403, 404)
   )
   
   if (httr::http_status(req)$message == "Success: (204) No Content")
@@ -106,12 +112,14 @@ boxDeleteFile <- function(file_id) {
 
 #' @keywords internal
 boxDeleteFolder <- function(dir_id) {
-  req <- httr::DELETE(
+  req <- httr::RETRY(
+    "DELETE",
     paste0(
       "https://api.box.com/2.0/folders/",
       dir_id, "?recursive=true"
     ),
-    get_token()
+    get_token(),
+    terminate_on = c(403, 404)
   )
   
   if (httr::http_status(req)$message == "Success: (204) No Content")

--- a/R/boxr_file_versions.R
+++ b/R/boxr_file_versions.R
@@ -27,12 +27,14 @@
 box_previous_versions <- function(file_id) {
   checkAuth()
   
-  req <- httr::GET(
+  req <- httr::RETRY(
+    "GET",
     paste0(
       "https://api.box.com/2.0/files/",
       file_id, "/versions"
     ),
-    get_token()
+    get_token(),
+    terminate_on = c(403, 404)
   )
   
 # The box API isn't very helpful if there are no previous versions. If this

--- a/R/boxr_invite.R
+++ b/R/boxr_invite.R
@@ -118,7 +118,8 @@ box_invite <- function(item, accessible_by, role, can_view_path = FALSE) {
   )
   
   # call the API
-  resp <- httr::POST(
+  resp <- httr::RETRY(
+    "POST",
     "https://api.box.com/2.0/collaborations",
     get_token(),
     encode = "multipart",
@@ -131,7 +132,8 @@ box_invite <- function(item, accessible_by, role, can_view_path = FALSE) {
           can_view_path = can_view_path
         ),
         auto_unbox = TRUE
-      )
+      ),
+    terminate_on = c(403, 404)
   ) 
   
   httr::stop_for_status(resp, task = "invite collaborator")

--- a/R/boxr_misc.R
+++ b/R/boxr_misc.R
@@ -68,9 +68,11 @@ box_pagination <- function(url, max){
   
   while (next_page) {
 
-    req <- httr::GET(
+    req <- httr::RETRY(
+      "GET",
       url,
-      get_token()
+      get_token(),
+      terminate_on = c(403, 404)
     )    
 
     if (req$status_code == 404) {
@@ -128,12 +130,14 @@ box_setwd <- function(dir_id) {
   
   checkAuth()
   
-  req <- httr::GET(
+  req <- httr::RETRY(
+    "GET",
     paste0(
       "https://api.box.com/2.0/folders/",
       box_id(dir_id)
     ),
-    get_token()
+    get_token(),
+    terminate_on = c(403, 404)
   )
   
   cont <- httr::content(req)
@@ -259,7 +263,8 @@ box_dir_create <- function(dir_name, parent_dir_id = box_getwd()) {
 
 #' @keywords internal
 boxDirCreate <- function(dir_name, parent_dir_id = box_getwd()) {
-  httr::POST(
+  httr::RETRY(
+    "POST",
     "https://api.box.com/2.0/folders/",
     get_token(),
     encode = "multipart",
@@ -267,6 +272,7 @@ boxDirCreate <- function(dir_name, parent_dir_id = box_getwd()) {
       paste0(
         '{"name":"', dir_name, '", "parent": {"id": "', box_id(parent_dir_id),
         '"}}'
-      )
+      ),
+    terminate_on = c(403, 404)
   )
 }

--- a/R/boxr_search.R
+++ b/R/boxr_search.R
@@ -196,9 +196,11 @@ box_search_pagination <- function(url, max = 200) {
   
   while (next_page) {
     page_url <- paste0(url, "&offset=", (page - 1) * 200)
-    req      <- httr::GET(
+    req      <- httr::RETRY(
+      "GET",
       page_url,
-      get_token()
+      get_token(),
+      terminate_on = c(403, 404)
     )
     
     if (req$status_code == 404) {


### PR DESCRIPTION
Thanks for for this awesome project!

In this PR, I'd like to propose swapping out calls to `httr::POST()`, `httr::GET()` etc. with `httr::RETRY()`. This will make the package more resilient to transient problems like brief network outages or periods where the service(s) it hits are overwhelmed. In my experience, using retry logic almost always improves the user experience with HTTP clients.

I'm working on https://github.com/chircollab/chircollab20/issues/1 as part of Chicago R Collab, an R 'unconference' in Chicago.