### PR TITLE
Fix usethis check error

### DIFF
--- a/R/boxr_auth.R
+++ b/R/boxr_auth.R
@@ -529,7 +529,7 @@ test_request <- function() {
 auth_message <- function(msg_client_info) {
 
   # if usethis installed, encourage to edit .Renviron
-  if (requireNamespace("usethis", quietly = FALSE)) {
+  if (requireNamespace("usethis", quietly = TRUE)) {
     
     # usethis message
     usethis::ui_todo(


### PR DESCRIPTION
`auth_message()` checks if usethis is installed, but it throws an error if it's not (when I saw this in the wild, it threw an error, then printed the second message). This PR changes the related argument of `requireNamespace()` to `quietly = TRUE` to only return `TRUE`/`FALSE`, not throw an error.