### PR TITLE
add diagnostic to test_request()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: boxr
 Type: Package
 Title: Interface for the 'Box.com API'
-Version: 0.3.5.9010
+Version: 0.3.5.9011
 Authors@R: c(
     person("Brendan", "Rocks", email = "foss@brendanrocks.com",
            role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Improvements
 
+* `box_auth()` and `box_auth_service()` print JSON response if test request returns error. (#166)
+
 * deprecates the `x` argument to `box_write()` in favor of `object`. (#187)
 
 * Some return objects can be printed as tibble (vs. data-frame). To enable this behavior, set `options(boxr.print_tibble = TRUE)` (perhaps in your `.Rprofile`).

--- a/R/boxr_auth.R
+++ b/R/boxr_auth.R
@@ -496,13 +496,29 @@ skip_if_no_token <- function() {
 # make a test request, indicate success, return content
 test_request <- function() {
  
-  test_response <- httr::RETRY("GET",
-                               "https://api.box.com/2.0/folders/0",
-                               get_token())
+  test_response <- 
+    httr::RETRY(
+      "GET",
+      "https://api.box.com/2.0/folders/0",
+      get_token()
+    )
+  
+  # looking for information detailed at 
+  # https://developer.box.com/guides/api-calls/permissions-and-errors/common-errors/#400-bad-request
+  status_code <- httr::status_code(test_response)
+  if (status_code %in% c(box_terminal_http_codes())) {
+     message("Error content:")
+     message(
+       jsonlite::prettify(
+         httr::content(test_response, as = "text", encoding = "UTF-8"),
+         indent = 2
+       )
+     )
+  }
+
+  cr <- httr::content(test_response)
   
   httr::stop_for_status(test_response, task = "connect to box.com API")
-  
-  cr <- httr::content(test_response)
   
   name <- cr$owned_by$name
   login <- cr$owned_by$login

--- a/R/boxr_auth.R
+++ b/R/boxr_auth.R
@@ -507,13 +507,15 @@ test_request <- function() {
   # https://developer.box.com/guides/api-calls/permissions-and-errors/common-errors/#400-bad-request
   status_code <- httr::status_code(test_response)
   if (status_code %in% c(box_terminal_http_codes())) {
+     message(glue::glue("status: {test_response$status_code}"))
      message("Error content:")
-     message(
-       jsonlite::prettify(
-         httr::content(test_response, as = "text", encoding = "UTF-8"),
-         indent = 2
-       )
-     )
+     message(str(test_response$content))
+     # message(
+     #   jsonlite::prettify(
+     #     httr::content(test_response, as = "text", encoding = "UTF-8"),
+     #     indent = 2
+     #   )
+     # )
   }
 
   cr <- httr::content(test_response)

--- a/R/boxr_auth.R
+++ b/R/boxr_auth.R
@@ -508,7 +508,7 @@ test_request <- function() {
   status_code <- httr::status_code(test_response)
   if (status_code %in% c(box_terminal_http_codes())) {
      message(glue::glue("status: {test_response$status_code}"))
-     message("Error content:")
+     # message("Error content:")
      message(str(test_response$content))
      # message(
      #   jsonlite::prettify(


### PR DESCRIPTION
This addresses #166 

The goal is to get more information on status-400 responses.

As a part of `box_auth()` and `box_auth_service()`, there is a call to the internal function `test_request()`. If it gets an error response, it will print out the JSON of the error response, which *should* look like one of these [sample responses at Box](https://developer.box.com/guides/api-calls/permissions-and-errors/common-errors/#400-bad-request).