### PR TITLE
Fix partial dollar matching for httr::http_status

### DIFF
--- a/R/boxr__internal_get.R
+++ b/R/boxr__internal_get.R
@@ -103,7 +103,7 @@ boxGet <- function(file_id, local_file, version_id = NULL, version_no = NULL,
   }
   
   # This could be more informative, but would require more requests
-  if (httr::http_status(req)$cat != "Success") {
+  if (httr::http_status(req)$category != "Success") {
     stop("Error downloading file id ", file_id, ": ", 
          httr::http_status(req)$message)
   }

--- a/R/boxr_upload_download.R
+++ b/R/boxr_upload_download.R
@@ -147,7 +147,7 @@ box_ul <- function(dir_id = box_getwd(), file, pb = options()$boxr.progress,
   ul_req <- box_upload_new(dir_id, file, pb = pb)
   
   # If uploading worked, end it here
-  if (httr::http_status(ul_req)$cat == "Success")
+  if (httr::http_status(ul_req)$category == "Success")
     return(add_file_ref_class(httr::content(ul_req)$entries[[1]]))
   
   # If it didn't work, because there's already a file with that name (http
@@ -165,7 +165,7 @@ box_ul <- function(dir_id = box_getwd(), file, pb = options()$boxr.progress,
                               file, dir_id, pb = pb)
     
     # If updating worked...
-    if (httr::http_status(ud_req)$cat == "Success") {
+    if (httr::http_status(ud_req)$category == "Success") {
       out <- add_file_ref_class(httr::content(ud_req)$entries[[1]])
       
       if (is.null(description)) {


### PR DESCRIPTION
The list returned by `httr::http_status` has components `category` and `message`. In 3 places ([1](https://github.com/r-box/boxr/compare/master...Zedseayou:master#diff-2df330d43c9cda53cd520dd1c0c06a059e4a7bcb0cf34bdd91fc2129ccdd3cdaR106), [2](https://github.com/r-box/boxr/compare/master...Zedseayou:master#diff-a32c3ab84f5185a1b27f18b60e5f81b2254cce5806e75a9a80ed743ed30a63fdR150), [3](https://github.com/r-box/boxr/compare/master...Zedseayou:master#diff-a32c3ab84f5185a1b27f18b60e5f81b2254cce5806e75a9a80ed743ed30a63fdR168)), the category is accessed with `$cat` instead, which generates a lot of warnings for anyone who has `options(warnPartialMatchDollar = TRUE)`. I changed these to silence the warnings and be consistent with other uses (e.g. [here](https://github.com/r-box/boxr/blob/e78ba39ab22c0401ffd9f01a3aba860494843d84/R/boxr__internal_diff_and_uldl.R#L115))

Apologies for the rest of the changes, which are just stripping trailing whitespace from empty lines caused by my RStudio settings. I can strip those from the pull request if needed.