### PR TITLE
windows error finding ~/.boxr-oauth

### DIFF
--- a/R/boxr_auth.R
+++ b/R/boxr_auth.R
@@ -235,7 +235,7 @@ box_fresh_auth <- function(cache = "~/.boxr-oauth", ...) {
   
   assertthat::assert_that(
     is.character(cache),
-    fs::file_exists(cache),
+    file.exists(cache),
     msg = "`cache` must be a valid filename"
   )
   


### PR DESCRIPTION
Ran into a similar problem as [JoeBradlee](https://github.com/JoeBradlee) in issue #219.  