### PR TITLE
patch token-location

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,7 +67,7 @@ Suggests:
     usethis,
     covr
 VignetteBuilder: knitr
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RdMacros: lifecycle

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: boxr
 Type: Package
 Title: Interface for the 'Box.com API'
-Version: 0.3.6.9000
+Version: 0.3.6.9001
 Authors@R: c(
     person("Brendan", "Rocks", email = "foss@brendanrocks.com",
            role = c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # boxr 0.3.6 (development)
 
+* harmonizes the default location for tokens. 
+  Now, `~` resolves to the home directory for all platforms. 
+  A patch is applied offering to move tokens from "old" locations.
+  (#219 w/@danielruss)
+
 * adds GitHub Actions for testing and coverage. (#206)
 
 # boxr 0.3.6

--- a/R/boxr__internal_misc.R
+++ b/R/boxr__internal_misc.R
@@ -49,7 +49,9 @@ is_void <- function(x) {
 # not it looks like the user has used boxr before
 boxrStartupMessage <- function() {
   
-  new_user <- !file.exists("~/.boxr-oauth")
+  path_cache <- harmonize_token_location("~/.boxr-oauth")
+  
+  new_user <- !file.exists(path_cache)
   
   if (new_user) {
     packageStartupMessage(

--- a/R/boxr_auth.R
+++ b/R/boxr_auth.R
@@ -673,11 +673,9 @@ harmonize_token_location <- function(cache) {
     return(path_cache)
   }
   
-  path <- ""
   if (fs::file_exists(path_r_cache)) {
-    # file in wrong location, offer to move it
-    path <- path_r_cache
     
+    # file in "bad" location, offer to move it
     if (interactive()) {
       msg <- glue::glue(
         "Token file found at `{path_r_cache}`.",
@@ -691,13 +689,18 @@ harmonize_token_location <- function(cache) {
         fs::file_move(path_r_cache, path_cache)
         path <- path_cache
         message(
-          glue::glue("Moved token file `{path_r_cache}` to `path_cache`.")
+          glue::glue("Moved token file `{path_r_cache}` to `{path_cache}`.")
         )
+        return(path_cache)
       }
+      
+      # declined, return "bad" location
+      return(path_r_cache)
       
     }
     
   }
     
-  path
+  # neither file exists, return "good" location
+  path_cache
 }

--- a/R/boxr_auth.R
+++ b/R/boxr_auth.R
@@ -79,6 +79,9 @@ box_auth <- function(client_id = NULL, client_secret = NULL,
     )
   }
   
+  # harmonize token-location
+  cache <- harmonize_token_location(cache)
+  
   # read environment variables
   client_id_env <- Sys.getenv("BOX_CLIENT_ID")
   client_secret_env <- Sys.getenv("BOX_CLIENT_SECRET")
@@ -232,6 +235,9 @@ box_auth <- function(client_id = NULL, client_secret = NULL,
 #' @export
 #' 
 box_fresh_auth <- function(cache = "~/.boxr-oauth", ...) {
+  
+  # harmonize token-location
+  cache <- harmonize_token_location(cache)
   
   assertthat::assert_that(
     is.character(cache),
@@ -409,7 +415,8 @@ box_auth_service <- function(token_file = NULL, token_text = NULL) {
 
     # %|0|% uses is_void()
     token_file <- token_file %|0|% token_file_env %|0|% "~/.boxr-auth/token.json"
-    
+
+    # no need to harmonize; this never went to the `Documents` folder on Windows
     token_file_path <- fs::path_real(token_file)
     if (!fs::file_exists(token_file_path)) {
       stop(
@@ -628,4 +635,69 @@ get_token <- function() {
   }
   
   stop("No token available", call. = FALSE)
+}
+
+#' Harmonize token location
+#' 
+#' The canonical location for tokens is in the `~` directory. Unfortunately,
+#' `~` resolves differently on Windows for R than it does for other languages.
+#' This has been a source of friction. The solution implemented by the r-lib
+#' team is that `fs::path_expand()` resolves only to the home directory.
+#' `fs::path_expand_r()` behaves like `path.expand()`, as `~` resolves to the 
+#' `Documents` folder, rather than the home folder.
+#' 
+#' boxr was built using the `path.expand()` philosophy; we are moving to the 
+#' r-lib philosophy.
+#' 
+#' The purpose of this function is to help manage the transition.
+#' 
+#' This function will look for the cache file in both locations. If the file is 
+#' found in the "wrong" location, it will offer to move it to the "right" 
+#' location.
+#' 
+#' It returns the absolute path to the cache file, if it exists.
+#'  
+#' @param cache `character` path to cache, unexpanded
+#' 
+#' @return `character` absolute path to cache
+#' 
+#' @noRd
+#'
+harmonize_token_location <- function(cache) {
+
+  path_cache <- fs::path_expand(cache)
+  path_r_cache <- fs::path_expand_r(cache)
+  
+  if (fs::file_exists(path_cache)) {
+    # success
+    return(path_cache)
+  }
+  
+  path <- ""
+  if (fs::file_exists(path_r_cache)) {
+    # file in wrong location, offer to move it
+    path <- path_r_cache
+    
+    if (interactive()) {
+      msg <- glue::glue(
+        "Token file found at `{path_r_cache}`.",
+        "Move token file to new boxr standard location `{path_cache}`? (Y/n): ",
+        sep = "\n"
+      )
+      str_move <- readline(prompt = msg)
+      
+      # we are moving the file
+      if (substr(str_move, 1, 1) %in% c("Y", "y", "")) {
+        fs::file_move(path_r_cache, path_cache)
+        path <- path_cache
+        message(
+          glue::glue("Moved token file `{path_r_cache}` to `path_cache`.")
+        )
+      }
+      
+    }
+    
+  }
+    
+  path
 }

--- a/R/boxr_auth.R
+++ b/R/boxr_auth.R
@@ -31,7 +31,9 @@
 #'   for you to authorize to your Box app.
 #'  
 #' - a token file is written, according to the value of `cache`. The default
-#'   behaviour is to write this file to `~/.boxr-oauth`.
+#'   behavior is to write this file to `~/.boxr-oauth`. 
+#'   For all platforms, `~` resolves to the home directory, i.e. path is
+#'   resolved using [fs::path_expand()] rather than [fs::path_expand_r()].
 #'
 #' - some global [options()] are set for your session to manage the token.
 #' 

--- a/R/boxr_auth.R
+++ b/R/boxr_auth.R
@@ -687,7 +687,6 @@ harmonize_token_location <- function(cache) {
       # we are moving the file
       if (substr(str_move, 1, 1) %in% c("Y", "y", "")) {
         fs::file_move(path_r_cache, path_cache)
-        path <- path_cache
         message(
           glue::glue("Moved token file `{path_r_cache}` to `{path_cache}`.")
         )

--- a/README.Rmd
+++ b/README.Rmd
@@ -30,7 +30,13 @@ A lightweight, *opinionated*, high-level R interface to the box.com API, standin
 
 ## New in boxr 0.3.6 (development)
 
-No changes yet; all changes are detailed in the [NEWS](`r url("news/")`).
+### Bug fixes
+
+- Harmonizes the default location for tokens; `~` resolves to the home directory for all platforms. 
+  A patch is applied offering to move tokens from "old" locations. 
+  This bug appeared on Windows only.
+
+All changes are detailed in the [NEWS](`r url("news/")`).
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 version](https://www.r-pkg.org/badges/version/boxr)](https://CRAN.R-project.org/package=boxr)
 [![R-CMD-check](https://github.com/r-box/boxr/workflows/R-CMD-check/badge.svg)](https://github.com/r-box/boxr/actions)
 [![codecov](https://codecov.io/gh/r-box/boxr/branch/master/graph/badge.svg?token=eeGrWfmg4P)](https://codecov.io/gh/r-box/boxr)
-![monthly\_downloads](https://cranlogs.r-pkg.org/badges/boxr)
+![monthly_downloads](https://cranlogs.r-pkg.org/badges/boxr)
 <!-- badges: end -->
 
 A lightweight, *opinionated*, high-level R interface to the box.com API,
@@ -21,7 +21,13 @@ easier for you to integrate your Box account into your R workflow.
 
 ## New in boxr 0.3.6 (development)
 
-No changes yet; all changes are detailed in the
+### Bug fixes
+
+-   Harmonizes the default location for tokens; `~` resolves to the home
+    directory for all platforms. A patch is applied offering to move
+    tokens from “old” locations. This bug appeared on Windows only.
+
+All changes are detailed in the
 [NEWS](https://r-box.github.io/boxr/news/).
 
 ## Installation
@@ -133,7 +139,7 @@ Conduct](https://r-box.github.io/boxr/CONDUCT.html).
 
 The MIT License (MIT)
 
-Copyright (c) 2015-2021 boxr contributors
+Copyright (c) 2015-2022 boxr contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the

--- a/man/box_auth_on_attach.Rd
+++ b/man/box_auth_on_attach.Rd
@@ -14,7 +14,7 @@ as soon as it's loaded.}
 Invisible \code{NULL}, called for side effects.
 }
 \description{
-\ifelse{html}{\figure{lifecycle-deprecated.svg}{options: alt='Deprecated lifecycle'}}{\strong{Deprecated}}
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
 \strong{This function is deprecated, and may be removed at the next release.}
 

--- a/man/box_dir_invite.Rd
+++ b/man/box_dir_invite.Rd
@@ -29,7 +29,7 @@ navigate parent-folders at Box.}
 Invisible \code{list()}.
 }
 \description{
-\ifelse{html}{\figure{lifecycle-deprecated.svg}{options: alt='Deprecated lifecycle'}}{\strong{Deprecated}}
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
 \code{box_dir_invite()} is deprecated in favor of \code{box_collab_create()}.
 }

--- a/man/box_previous_versions.Rd
+++ b/man/box_previous_versions.Rd
@@ -13,7 +13,7 @@ box_previous_versions(file_id)
 \code{data.frame} describing previous versions of file.
 }
 \description{
-\ifelse{html}{\out{<a href='https://www.tidyverse.org/lifecycle/#superseded'><img src='figures/lifecycle-superseded.svg' alt='Superseded lifecycle'></a>}}{\strong{Superseded}}
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#superseded}{\figure{lifecycle-superseded.svg}{options: alt='[Superseded]'}}}{\strong{[Superseded]}}
 
 Superseded by \code{\link[=box_version_history]{box_version_history()}}.
 }


### PR DESCRIPTION
aims to fix #219 

I still need put this into the documentation.

Basically, it looks for the token file in both locations, then if it exists only in the "bad" location, it offers to move it to the "good" location, then carries on.

@nathancday @danielruss can you let me know what you think?

Daniel - sorry to have stepped on your PR and kind offer of help - it is very much appreciated, and I look forward to hearing if this takes care of the problem.