### PR TITLE
Add box_url param to relevant functions; update docs

### DIFF
--- a/R/boxr_misc.R
+++ b/R/boxr_misc.R
@@ -287,6 +287,7 @@ boxDirCreate <- function(dir_name, parent_dir_id = box_getwd()) {
 #' 
 #' @param dir_id `numeric` or `character`, folder ID at Box.
 #' @param file_id `numeric` or `character`, file ID at Box. 
+#' @param box_url `character`,  url for box defaulting to https://app.box.com/;
 #' 
 #' @return `r string_side_effects()`
 #' 
@@ -298,7 +299,7 @@ boxDirCreate <- function(dir_name, parent_dir_id = box_getwd()) {
 #' 
 #' @export
 #' 
-box_browse <- function(dir_id = NULL, file_id = NULL) {
+box_browse <- function(dir_id = NULL, file_id = NULL, box_url="https://app.box.com") {
   item <- collab_item_helper(dir_id, file_id)
-  utils::browseURL(glue::glue("https://app.box.com/{item$type}/{item$id}"))
+  utils::browseURL(glue::glue("{box_url}/{item$type}/{item$id}"))
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -81,6 +81,15 @@ box_auth()
 
 If you don't have access to `client_id` and `client_secret`, you should read the [authentication article](`r url("articles/boxr-apps.html")`) to determine your next steps. In most cases, this next step will be to create an [interactive Box-app](`r url("articles/boxr-app-interactive.html")`) 
 
+### Authentication for Enterprise Box
+To use `boxr` with enterprise accounts, the `box_url` parameter must be set:
+
+```r
+box_auth(client_id = "your_client_id", client_secret = "your_client_secret", box_url = "https://wayne-enterprises.ent.box.com")
+```
+You can also set the `BOX_URL` environment variable to your URL.
+
+
 ### Basic operations
 
   - [Accessing Box files](`r url("articles/boxr.html#files")`): `box_ul()`, `box_dl()`, `box_version_history()`.

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ easier for you to integrate your Box account into your R workflow.
 
 ### Bug fixes
 
--   Harmonizes the default location for tokens; `~` resolves to the home
-    directory for all platforms. A patch is applied offering to move
-    tokens from “old” locations. This bug appeared on Windows only.
+- Harmonizes the default location for tokens; `~` resolves to the home
+  directory for all platforms. A patch is applied offering to move
+  tokens from “old” locations. This bug appeared on Windows only.
 
 All changes are detailed in the
 [NEWS](https://r-box.github.io/boxr/news/).
@@ -52,8 +52,8 @@ The package-documentation website is created and maintained using
 [pkgdown](https://pkgdown.r-lib.org). The documentation website consists
 of:
 
--   a [CRAN-version site](https://r-box.github.io/boxr/).
--   a [development-version site](https://r-box.github.io/boxr/dev/).
+- a [CRAN-version site](https://r-box.github.io/boxr/).
+- a [development-version site](https://r-box.github.io/boxr/dev/).
 
 ## Usage
 
@@ -86,46 +86,56 @@ determine your next steps. In most cases, this next step will be to
 create an [interactive
 Box-app](https://r-box.github.io/boxr/articles/boxr-app-interactive.html)
 
+### Authentication for Enterprise Box
+
+To use `boxr` with enterprise accounts, the `box_url` parameter must be
+set:
+
+``` r
+box_auth(client_id = "your_client_id", client_secret = "your_client_secret", box_url = "https://wayne-enterprises.ent.box.com")
+```
+
+You can also set the `BOX_URL` environment variable to your URL.
+
 ### Basic operations
 
--   [Accessing Box
-    files](https://r-box.github.io/boxr/articles/boxr.html#files):
-    `box_ul()`, `box_dl()`, `box_version_history()`.
--   [Accessing Box
-    directories](https://r-box.github.io/boxr/articles/boxr.html#directories):
-    `box_setwd()`, `box_getwd()`, `box_dir_create()`, `box_ls()`,
-    `box_search()`.
--   [Directory-wide
-    operations](https://r-box.github.io/boxr/articles/boxr.html#directory-wide-operations):
-    `box_push()`, `box_fetch()`.
+- [Accessing Box
+  files](https://r-box.github.io/boxr/articles/boxr.html#files):
+  `box_ul()`, `box_dl()`, `box_version_history()`.
+- [Accessing Box
+  directories](https://r-box.github.io/boxr/articles/boxr.html#directories):
+  `box_setwd()`, `box_getwd()`, `box_dir_create()`, `box_ls()`,
+  `box_search()`.
+- [Directory-wide
+  operations](https://r-box.github.io/boxr/articles/boxr.html#directory-wide-operations):
+  `box_push()`, `box_fetch()`.
 
 ### Advanced operations
 
--   [Interactng with Box
-    files](https://r-box.github.io/boxr/articles/boxr.html#box-file-interaction):
-    `box_collab_create()`, `box_comment_create()`,
-    `box_add_description()`.
--   [Using Box
-    trash](https://r-box.github.io/boxr/articles/boxr.html#using-box-trash):
-    `box_delete_file()`, `box_delete_folder()`, `box_restore_file()`,
-    `box_restore_folder()`.
--   [Interacting with your R
-    session](https://r-box.github.io/boxr/articles/boxr.html#interacting-with-your-r-session):
-    `box_read()`, `box_write()`, `box_read_rds()`, `box_save_rds()`,
-    `box_save()`, `box_load()`, `box_browse()`.
+- [Interactng with Box
+  files](https://r-box.github.io/boxr/articles/boxr.html#box-file-interaction):
+  `box_collab_create()`, `box_comment_create()`,
+  `box_add_description()`.
+- [Using Box
+  trash](https://r-box.github.io/boxr/articles/boxr.html#using-box-trash):
+  `box_delete_file()`, `box_delete_folder()`, `box_restore_file()`,
+  `box_restore_folder()`.
+- [Interacting with your R
+  session](https://r-box.github.io/boxr/articles/boxr.html#interacting-with-your-r-session):
+  `box_read()`, `box_write()`, `box_read_rds()`, `box_save_rds()`,
+  `box_save()`, `box_load()`, `box_browse()`.
 
 ## Alternatives
 
 Other ways to interact with a Box account include:
 
--   The [Box desktop apps](https://www.box.com/resources/downloads).
--   The *other* boxr, [written in
-    Ruby](https://github.com/cburnette/boxr). Its motivations are rather
-    different, and it covers 100% of the box.com API (e.g account
-    administration, etc.).
--   Box themselves provide a [wide range of
-    SDKs](https://github.com/box), including [one for
-    Python](https://github.com/box/box-python-sdk).
+- The [Box desktop apps](https://www.box.com/resources/downloads).
+- The *other* boxr, [written in
+  Ruby](https://github.com/cburnette/boxr). Its motivations are rather
+  different, and it covers 100% of the box.com API (e.g account
+  administration, etc.).
+- Box themselves provide a [wide range of SDKs](https://github.com/box),
+  including [one for Python](https://github.com/box/box-python-sdk).
 
 ## Contributing
 
@@ -139,7 +149,7 @@ Conduct](https://r-box.github.io/boxr/CONDUCT.html).
 
 The MIT License (MIT)
 
-Copyright (c) 2015-2022 boxr contributors
+Copyright (c) 2015-2023 boxr contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the

--- a/man/box_auth.Rd
+++ b/man/box_auth.Rd
@@ -7,6 +7,7 @@
 box_auth(
   client_id = NULL,
   client_secret = NULL,
+  box_url = NULL,
   interactive = TRUE,
   cache = "~/.boxr-oauth",
   write.Renv,
@@ -19,6 +20,9 @@ the client id for the account to use.}
 
 \item{client_secret}{\code{character},
 the client secret for the account to use.}
+
+\item{box_url}{\code{character},
+the url to box.  Defaults to https://app.box.com, but can be set to enterprise Box URLs}
 
 \item{interactive}{\code{logical}, indicates that the authorization process
 will be interactive (requiring user input to the R console, and/or a
@@ -68,7 +72,9 @@ This function has some side effects which make subsequent calls to
 \item a browser window may be opened at \href{https://developer.box.com/docs}{box.com},
 for you to authorize to your Box app.
 \item a token file is written, according to the value of \code{cache}. The default
-behaviour is to write this file to \verb{~/.boxr-oauth}.
+behavior is to write this file to \verb{~/.boxr-oauth}.
+For all platforms, \code{~} resolves to the home directory, i.e. path is
+resolved using \code{\link[fs:path_expand]{fs::path_expand()}} rather than \code{\link[fs:path_expand]{fs::path_expand_r()}}.
 \item some global \code{\link[=options]{options()}} are set for your session to manage the token.
 \item environment variables \code{BOX_USER_ID}, \code{BOX_CLIENT_ID},
 and \code{BOX_CLIENT_SECRET} are set.

--- a/man/box_browse.Rd
+++ b/man/box_browse.Rd
@@ -4,12 +4,14 @@
 \alias{box_browse}
 \title{Open a Box directory or file in browser}
 \usage{
-box_browse(dir_id = NULL, file_id = NULL)
+box_browse(dir_id = NULL, file_id = NULL, box_url = "https://app.box.com")
 }
 \arguments{
 \item{dir_id}{\code{numeric} or \code{character}, folder ID at Box.}
 
 \item{file_id}{\code{numeric} or \code{character}, file ID at Box.}
+
+\item{box_url}{\code{character},  url for box defaulting to https://app.box.com/;}
 }
 \value{
 Invisible \code{NULL}, called for side effects.


### PR DESCRIPTION
See issue #240 

This addresses the issue of accessing enterprise box accounts by adding optional args to the `box_auth` and `box_browse` functions.   I have tried to mirror the behaviour with the client secrets/id where it will look for a `BOX_URL` environment variable if `box_url` is not set.

This works on my company's enterprise Box setup, but should probably be checked on someone else's as well.

Happy to discuss further and make any needed changes!