### PR TITLE
refactor: use withr to manage tempfiles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: boxr
 Type: Package
 Title: Interface for the 'Box.com API'
-Version: 0.3.6.9005
+Version: 0.3.6.9006
 Authors@R: c(
     person("Brendan", "Rocks", email = "foss@brendanrocks.com",
            role = c("aut")),
@@ -52,7 +52,8 @@ Imports:
     tibble,
     lifecycle,
     jsonlite,
-    jose
+    jose,
+    withr
 Suggests:
     clipr (>= 0.3.0),
     conflicted,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Internal
 
+* refactor to use withr functions to handle temp files. (#183)
+
 * update documentation to reflect updates to rio package. (#242, @chainsawriot)
 
 * update maintainer's email address. (#248)

--- a/R/boxr__internal_misc.R
+++ b/R/boxr__internal_misc.R
@@ -294,7 +294,6 @@ create_test_dir <- function() {
   return()  
 }
 
-
 # A function to modify that directory structure
 modify_test_dir <- function() {
   # Delete a directory
@@ -314,9 +313,8 @@ modify_test_dir <- function() {
 
 # A function to clear out a box.com directory
 clear_box_dir <- function(dir_id) {
-  dir.create("delete_me", showWarnings = FALSE)
-  box_push(dir_id, "delete_me", delete = TRUE)
-  unlink("delete_me", recursive = TRUE, force = TRUE)
+  tmp_dir <- withr::local_tempdir()
+  box_push(dir_id, tmp_dir, delete = TRUE)
 }
 
 

--- a/R/boxr_read.R
+++ b/R/boxr_read.R
@@ -54,7 +54,7 @@ box_read <- function(file_id, type = NULL, version_id = NULL,
                      ...) {
   checkAuth()
   
-  temp_file <- tempfile()
+  temp_file <- withr::local_tempfile() 
   
   # Make the request
   req <- boxGet(file_id, local_file = temp_file, version_id = version_id, 
@@ -105,9 +105,6 @@ box_read <- function(file_id, type = NULL, version_id = NULL,
   if ("data.frame" %in% class(cont) & is.null(attr(cont, "row.names"))) {
     cont <- unclass(cont)
   }
-  
-  # Delete the tempfile
-  unlink(temp_file, force = TRUE)
   
   message(
     "Remote file '", new_name, "' read into memory as an object of class ", 

--- a/R/boxr_read.R
+++ b/R/boxr_read.R
@@ -60,7 +60,7 @@ box_read <- function(file_id, type = NULL, version_id = NULL,
   req <- boxGet(file_id, local_file = temp_file, version_id = version_id, 
                 version_no = version_no, download = TRUE)
 
-  # Extract the filename
+  # Extract the filename and extension
   filename <- gsub(
     'filename=\"|\"', '',
     stringr::str_extract(
@@ -68,15 +68,15 @@ box_read <- function(file_id, type = NULL, version_id = NULL,
       'filename=\"(.*?)\"'
     )
   )
+  file_ext <- glue::glue(".{fs::path_ext(filename)}")
   
-  # Give the file it's original name back, so that you can preserve the file
-  # extension
-  new_name <- paste0(tempdir(), "/", filename)
-  file.rename(temp_file, new_name)
+  # Give the file its original file-extension back
+  temp_file_new <- withr::local_tempfile(fileext = file_ext)
+  file.rename(temp_file, temp_file_new)
   
   # If the file doesn't have an obvious file extension, try and do the right
   # thing by considering the mime-type from the request
-  if (!grepl("\\.[[:alnum:]]+$", new_name)) {
+  if (!grepl("\\.[[:alnum:]]+$", temp_file_new)) {
     message("Cannot read file extension from name.\n",
             "Inferring from mime-type...\n")
     mime <- req$headers$`content-type`
@@ -88,13 +88,13 @@ box_read <- function(file_id, type = NULL, version_id = NULL,
     # Supply the file format to read_fun, if it seems to accept them (the 
     # default, rio::import, does)
     if ("format" %in% names(formals(read_fun))) {
-      cont <- read_fun(new_name, format = ext, ...)
+      cont <- read_fun(temp_file_new, format = ext, ...)
     } else {
       # Otherwise, just try and read it with a user-supplied function
-      cont <- read_fun(new_name, ...)
+      cont <- read_fun(temp_file_new, ...)
     }
   } else {
-    cont <- read_fun(new_name, ...)
+    cont <- read_fun(temp_file_new, ...)
   }
   
   # this code comment is old (i think) and maybe worth revisiting was rio goes to CRAN (NCD 2019-11-01)
@@ -107,7 +107,7 @@ box_read <- function(file_id, type = NULL, version_id = NULL,
   }
   
   message(
-    "Remote file '", new_name, "' read into memory as an object of class ", 
+    "Remote file '", filename, "' read into memory as an object of class ", 
     paste(class(cont), collapse = ", "),
     "\n"
   )

--- a/R/boxr_save_load.R
+++ b/R/boxr_save_load.R
@@ -31,8 +31,8 @@
 box_save <- function(..., dir_id = box_getwd(), file_name = ".RData", 
                      description = NULL) {
   
-  temp_file <- withr::local_tempfile(pattern = file_name)
-  
+  temp_file <- fs::path(withr::local_tempdir(), file_name)
+
   save(..., envir = parent.frame(), file = temp_file)
   
   box_ul(dir_id, temp_file, description = description)

--- a/R/boxr_save_load.R
+++ b/R/boxr_save_load.R
@@ -31,14 +31,7 @@
 box_save <- function(..., dir_id = box_getwd(), file_name = ".RData", 
                      description = NULL) {
   
-  # TODO: fs
-  #temp_file <- withr::local_tempfile(pattern = file_name)
-  temp_file <- normalizePath(file.path(tempdir(), file_name), mustWork = FALSE)
-  
-  # clean up after ourselves
-  # TODO: withr 2.3.0 may have a cleaner way to do this: local_tempfile()
-  #   - see https://github.com/r-lib/usethis/issues/1217
-  on.exit(fs::file_delete(temp_file))
+  temp_file <- withr::local_tempfile(pattern = file_name)
   
   save(..., file = temp_file)
   

--- a/R/boxr_save_load.R
+++ b/R/boxr_save_load.R
@@ -57,8 +57,7 @@ box_save_image <- function(dir_id = box_getwd(), file_name = ".RData",
     }
   }
   
-  # using local_tempdir() rather than local_tempfile() to preserve the 
-  # entire filename
+  # using local_tempdir() to preserve the filename
   temp_dir <- withr::local_tempdir()
   temp_file <- fs::path(temp_dir, file_name)
 
@@ -71,9 +70,9 @@ box_save_image <- function(dir_id = box_getwd(), file_name = ".RData",
 #' @export
 #' 
 box_load <- function(file_id) {  
-  temp_dir  <- tempdir()
+  # using local_tempdir() to preserve the filename
+  temp_dir  <- withr::local_tempdir()
   temp_file <- box_dl(file_id, overwrite = TRUE, local_dir = temp_dir)
-  on.exit(fs::file_delete(temp_file))
   
   load(temp_file, envir = globalenv())
 }

--- a/R/boxr_save_load.R
+++ b/R/boxr_save_load.R
@@ -31,6 +31,7 @@
 box_save <- function(..., dir_id = box_getwd(), file_name = ".RData", 
                      description = NULL) {
   
+  # using local_tempdir() to preserve the filename
   temp_file <- fs::path(withr::local_tempdir(), file_name)
 
   save(..., envir = parent.frame(), file = temp_file)
@@ -58,8 +59,7 @@ box_save_image <- function(dir_id = box_getwd(), file_name = ".RData",
   }
   
   # using local_tempdir() to preserve the filename
-  temp_dir <- withr::local_tempdir()
-  temp_file <- fs::path(temp_dir, file_name)
+  temp_file <- fs::path(withr::local_tempdir(), file_name)
 
   save.image(file = temp_file)
   

--- a/R/boxr_save_load.R
+++ b/R/boxr_save_load.R
@@ -32,6 +32,7 @@ box_save <- function(..., dir_id = box_getwd(), file_name = ".RData",
                      description = NULL) {
   
   # TODO: fs
+  #temp_file <- withr::local_tempfile(pattern = file_name)
   temp_file <- normalizePath(file.path(tempdir(), file_name), mustWork = FALSE)
   
   # clean up after ourselves

--- a/R/boxr_save_load.R
+++ b/R/boxr_save_load.R
@@ -57,10 +57,11 @@ box_save_image <- function(dir_id = box_getwd(), file_name = ".RData",
     }
   }
   
-  # TODO: fs
-  temp_file <- normalizePath(file.path(tempdir(), file_name), mustWork = FALSE)
-  on.exit(fs::file_delete(temp_file))
-  
+  # using local_tempdir() rather than local_tempfile() to preserve the 
+  # entire filename
+  temp_dir <- withr::local_tempdir()
+  temp_file <- fs::path(temp_dir, file_name)
+
   save.image(file = temp_file)
   
   box_ul(dir_id, temp_file, description = description)

--- a/R/boxr_source.R
+++ b/R/boxr_source.R
@@ -19,7 +19,7 @@
 #' @export
 #' 
 box_source <- function(file_id, local = globalenv(), ...) {
-  temp_dir  <- tempdir()
+  temp_dir  <- withr::local_tempdir()
   temp_file <- box_dl(file_id, overwrite = TRUE, local_dir = temp_dir)
   source(temp_file, local = local, ...)
 }

--- a/R/boxr_upload_download.R
+++ b/R/boxr_upload_download.R
@@ -83,7 +83,7 @@ box_dl <- function(file_id, local_dir = getwd(), overwrite = FALSE,
     stop("File already exists locally, and overwrite = FALSE")
   
   # Get a temp file
-  temp_file <- tempfile()
+  temp_file <- withr::local_tempfile()
   
   # Download to a tempfile with boxGet
   req <- boxGet(file_id = file_id, version_id = version_id,
@@ -126,9 +126,6 @@ box_dl <- function(file_id, local_dir = getwd(), overwrite = FALSE,
   if (!cp)
     stop("Problem writing file to ", new_file, 
          ".\n Check that directory is writable.")
-  
-  # Remove the tempfile to free up space
-  file.remove(temp_file)
   
   return(new_file)
 }

--- a/R/boxr_write.R
+++ b/R/boxr_write.R
@@ -68,7 +68,10 @@ box_write <- function(object, file_name, dir_id = box_getwd(), description = NUL
     }
   }
   
-  temp_file <- paste0(tempdir(), "/", file_name)
+  # using local_tempdir() to preserve the filename
+  temp_dir <- withr::local_tempdir()
+  temp_file <- fs::path(temp_dir, file_name)
+  
   write_fun(object, temp_file, ...)
   box_ul(dir_id = dir_id, file = temp_file, description = description)
 }

--- a/R/boxr_write.R
+++ b/R/boxr_write.R
@@ -69,9 +69,8 @@ box_write <- function(object, file_name, dir_id = box_getwd(), description = NUL
   }
   
   # using local_tempdir() to preserve the filename
-  temp_dir <- withr::local_tempdir()
-  temp_file <- fs::path(temp_dir, file_name)
-  
+  temp_file <- fs::path(withr::local_tempdir(), file_name)
+
   write_fun(object, temp_file, ...)
   box_ul(dir_id = dir_id, file = temp_file, description = description)
 }

--- a/tests/testthat/test_02_clear_out.R
+++ b/tests/testthat/test_02_clear_out.R
@@ -20,7 +20,7 @@ test_that("Clear out the remote directory", {
   options(boxr.verbose = FALSE)
   # Tell boxr to sync the remote home directory with an empty local one
   # (i.e. delete everything)
-  b <- box_push(0, fs::path_temp("test_dir/dir_12/dir_121/dir_1211"), delete = TRUE)
+  boxr:::clear_box_dir(0)
   
   expect_length(box_ls(0), 0)
   

--- a/tests/testthat/test_05_read_write.R
+++ b/tests/testthat/test_05_read_write.R
@@ -8,7 +8,7 @@ test_that("You can source a remote R script", {
   skip_if_no_token()
   
   # Write a little R script
-  tf <- paste(tempfile(), ".R")
+  tf <- withr::local_tempfile(fileext = ".R")
   writeLines("test_vector <- 1:10\n", tf)
   
   # Upload it, so that you can 'source it' back down
@@ -26,7 +26,7 @@ test_that("You can write/read a remote .csv file", {
   skip_if_no_token()
   
   # Write a little .csv file
-  tf <- paste0(tempfile(), ".csv")
+  tf <- withr::local_tempfile(fileext = ".csv")
   # Note: It looks like although httr says it uses read.csv for the .csv files,
   # it doesn't obey the usual R behaviour of treating strings as factors by
   # default. So to get two objects that match, you'll need to make sure they're
@@ -58,7 +58,7 @@ test_that("You can write/read a remote .tsv file", {
   skip_if_no_token()
   
   # Write a little .tsv file
-  tf <- paste0(tempfile(), ".tsv")
+  tf <- withr::local_tempfile(fileext = ".tsv")
   
   df <- data.frame(a = letters[1:5], b = 1:5, c = rnorm(5), 
                    stringsAsFactors = FALSE)
@@ -88,7 +88,7 @@ test_that("You can write/read a remote .json file", {
   skip_if_no_token()
   
   # Write a little .json file
-  tf <- paste0(tempfile(), ".json")
+  tf <- withr::local_tempfile(fileext = ".json")
   df <- data.frame(a = letters[1:5], b = 1:5, c = rnorm(5),
                    stringsAsFactors = FALSE)
   l  <- list(a = 1:10, b = matrix(1, 3, 3), c = df)

--- a/tests/testthat/test_99_tidy_up.R
+++ b/tests/testthat/test_99_tidy_up.R
@@ -5,8 +5,7 @@ test_that("Box directory is emptied", {
   boxr:::skip_on_travis()
   skip_if_no_token()
   
-  # push empty local dir to top level on Box
-  b <- box_push(0, fs::path_temp("test_dir/dir_12/dir_121/dir_1211"), delete = TRUE)
+  boxr:::clear_box_dir(0)
   
   expect_equal(nrow(as.data.frame(box_ls(0))), 0)
 })


### PR DESCRIPTION
use `withr::local_tempfile()` and `withr::local_tempdir()` to simplify temporary files

fix #183